### PR TITLE
http: add ResponseWriter from auth and paygate projects

### DIFF
--- a/http/doc.go
+++ b/http/doc.go
@@ -1,0 +1,12 @@
+// Copyright 2018 The Moov Authors
+// Use of this source code is governed by an Apache License
+// license that can be found in the LICENSE file.
+
+// Package http implements a core suite of HTTP functions for use inside Moov. These packages are designed to
+// be used in production to provide insight without an excessive performance tradeoff.
+//
+// This package implements several opininated response functions (See Problem, InternalError) and stateless CORS
+// handling under our load balancing setup. They may not work for you.
+//
+// This package also implements a wrapper around http.ResponseWriter to log X-Request-ID, timing and the resulting status code.
+package http

--- a/http/response.go
+++ b/http/response.go
@@ -1,0 +1,111 @@
+// Copyright 2018 The Moov Authors
+// Use of this source code is governed by an Apache License
+// license that can be found in the LICENSE file.
+
+package http
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/moov-io/base/idempotent"
+
+	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/metrics"
+)
+
+var (
+	ErrNoUserId = errors.New("no X-User-Id header provided")
+)
+
+type ResponseWriter struct {
+	http.ResponseWriter
+
+	start   time.Time
+	request *http.Request
+	metric  metrics.Histogram
+
+	headersWritten bool // set on WriteHeader
+
+	log log.Logger
+}
+
+func (w *ResponseWriter) WriteHeader(code int) {
+	if w.headersWritten {
+		return
+	}
+	w.headersWritten = true
+
+	// Headers
+	SetAccessControlAllowHeaders(w, w.request)
+	defer w.ResponseWriter.WriteHeader(code)
+
+	// Record route timing
+	diff := time.Since(w.start)
+	if w.metric != nil {
+		w.metric.Observe(diff.Seconds())
+	}
+
+	// Skip Go's content sniff here to speed up response timing for client
+	if w.ResponseWriter.Header().Get("Content-Type") == "" {
+		w.ResponseWriter.Header().Set("Content-Type", "text/plain")
+		w.ResponseWriter.Header().Set("X-Content-Type-Options", "nosniff")
+	}
+
+	if requestId := GetRequestId(w.request); requestId != "" && w.log != nil {
+		var buf strings.Builder
+		buf.WriteString(fmt.Sprintf("method=%s ", w.request.Method))
+		buf.WriteString(fmt.Sprintf("path=%s ", w.request.URL.Path))
+		buf.WriteString(fmt.Sprintf("status=%d ", code))
+		buf.WriteString(fmt.Sprintf("took=%s ", diff))
+		buf.WriteString(fmt.Sprintf("requestId=%s ", requestId))
+
+		w.log.Log(w.request.Method, buf.String())
+	}
+}
+
+// Wrap returns a ResponseWriter usable by applications. No parts of the request are inspected.
+func Wrap(logger log.Logger, m metrics.Histogram, w http.ResponseWriter, r *http.Request) *ResponseWriter {
+	now := time.Now()
+	return &ResponseWriter{
+		ResponseWriter: w,
+		start:          now,
+		request:        r,
+		metric:         m,
+		log:            logger,
+	}
+}
+
+// EnsureHeaders wraps the http.ResponseWriter but also checks Moov specific headers.
+//
+// X-User-Id is required, and requests without one will be completed with a 403 forbidden.
+// No lookup is done to ensure the value exists and is valid for a Moov user.
+//
+// X-Request-Id is optional, but if used we will emit a log line with that request fulfillment timing
+// and the status code.
+//
+// X-Idempotency-Key is optional, but recommended to ensure requests only execute once. Clients are
+// assumed to resend requests many times with the same key. We just need to reply back "already done".
+func EnsureHeaders(logger log.Logger, m metrics.Histogram, rec idempotent.Recorder, w http.ResponseWriter, r *http.Request) (*ResponseWriter, error) {
+	writer := Wrap(logger, m, w, r)
+	return writer, writer.ensureHeaders(rec)
+}
+
+// ensureHeaders verifies the headers which Moov apps all cares about.
+func (w *ResponseWriter) ensureHeaders(rec idempotent.Recorder) error {
+	if userId := GetUserId(w.request); userId == "" {
+		if !w.headersWritten {
+			w.Header().Set("Content-Type", "text/plain")
+			w.WriteHeader(http.StatusForbidden)
+		}
+		return ErrNoUserId
+	}
+	if _, seen := idempotent.FromRequest(w.request, rec); seen {
+		idempotent.SeenBefore(w)
+		return idempotent.ErrSeenBefore
+	}
+	return nil
+}

--- a/http/response_test.go
+++ b/http/response_test.go
@@ -1,0 +1,71 @@
+// Copyright 2018 The Moov Authors
+// Use of this source code is governed by an Apache License
+// license that can be found in the LICENSE file.
+
+package http
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/moov-io/base/idempotent/lru"
+)
+
+func TestResponse__Wrap(t *testing.T) {
+	req := httptest.NewRequest("GET", "https://api.moov.io/v1/ach/ping", nil)
+	req.Header.Set("Origin", "https://moov.io/demo")
+
+	w := httptest.NewRecorder()
+	ww := Wrap(nil, nil, w, req)
+	ww.WriteHeader(http.StatusTeapot)
+	w.Flush()
+
+	if w.Code != http.StatusTeapot {
+		t.Errorf("got HTTP code: %d", w.Code)
+	}
+	if v := w.Header().Get("Access-Control-Allow-Origin"); v == "" {
+		t.Error("expected CORS heders")
+	}
+}
+
+func TestResposne_EnsureHeaders(t *testing.T) {
+	req := httptest.NewRequest("GET", "https://api.moov.io/v1/ach/ping", nil)
+	req.Header.Set("x-user-id", "junk")
+	req.Header.Set("Origin", "https://moov.io/demo")
+
+	rec := lru.New()
+	w := httptest.NewRecorder()
+
+	ww, err := EnsureHeaders(nil, nil, rec, w, req)
+	if err != nil {
+		t.Error(err)
+	}
+
+	ww.WriteHeader(http.StatusTeapot)
+	w.Flush()
+
+	if w.Code != http.StatusTeapot {
+		t.Errorf("got HTTP code: %d", w.Code)
+	}
+	if v := w.Header().Get("Access-Control-Allow-Origin"); v == "" {
+		t.Error("expected CORS heders")
+	}
+}
+
+func TestResponse__EnsureHeadersFail(t *testing.T) {
+	req := httptest.NewRequest("GET", "https://api.moov.io/v1/ach/ping", nil)
+
+	w := httptest.NewRecorder()
+	ww, err := EnsureHeaders(nil, nil, nil, w, req)
+	if err == nil {
+		t.Errorf("expected error")
+	}
+
+	ww.WriteHeader(http.StatusTeapot)
+	w.Flush()
+
+	if w.Code != http.StatusForbidden {
+		t.Errorf("got HTTP code: %d", w.Code)
+	}
+}

--- a/http/server.go
+++ b/http/server.go
@@ -2,8 +2,6 @@
 // Use of this source code is governed by an Apache License
 // license that can be found in the LICENSE file.
 
-// Package http implements a base Moov HTTP server. This is intended to be used
-// by all services as a baseline for secure, production ready services.
 package http
 
 import (

--- a/idempotent/idempotent.go
+++ b/idempotent/idempotent.go
@@ -5,7 +5,12 @@
 package idempotent
 
 import (
+	"errors"
 	"net/http"
+)
+
+var (
+	ErrSeenBefore = errors.New("X-Idempotency-Key seen before")
 )
 
 // Recorder offers a method to determine if a given key has been
@@ -17,8 +22,13 @@ type Recorder interface {
 
 // FromRequest extracts the idempotency key from HTTP headers and records its presence in
 // the provided Recorder.
+//
+// A nil Recorder will always return idempotency keys as unseen.
 func FromRequest(req *http.Request, rec Recorder) (key string, seen bool) {
 	key = req.Header.Get("X-Idempotency-Key")
+	if rec == nil {
+		return key, false
+	}
 	if key == "" {
 		return "", false
 	}

--- a/idempotent/idempotent_test.go
+++ b/idempotent/idempotent_test.go
@@ -1,0 +1,64 @@
+// Copyright 2018 The Moov Authors
+// Use of this source code is governed by an Apache License
+// license that can be found in the LICENSE file.
+
+package idempotent
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestIdempotent(t *testing.T) {
+	req := httptest.NewRequest("GET", "/ping", nil)
+	req.Header.Set("X-Idempotency-Key", "test")
+
+	key, seen := FromRequest(req, nil)
+	if key != "test" {
+		t.Errorf("got %q", key)
+	}
+	if seen {
+		t.Errorf("shouldn't be marked as seen")
+	}
+
+	// Do it all again to make sure
+	key, seen = FromRequest(req, nil)
+	if key != "test" {
+		t.Errorf("got %q", key)
+	}
+	if seen {
+		t.Errorf("shouldn't be marked as seen")
+	}
+}
+
+func TestIdempotent__Empty(t *testing.T) {
+	req := httptest.NewRequest("GET", "/ping", nil)
+
+	key, seen := FromRequest(req, nil)
+	if key != "" {
+		t.Errorf("got %q", key)
+	}
+	if seen {
+		t.Errorf("shouldn't be marked as seen")
+	}
+
+	// Do it all again to make sure
+	key, seen = FromRequest(req, nil)
+	if key != "" {
+		t.Errorf("got %q", key)
+	}
+	if seen {
+		t.Errorf("shouldn't be marked as seen")
+	}
+}
+
+func TestIdempotent__SeenBefore(t *testing.T) {
+	w := httptest.NewRecorder()
+	SeenBefore(w)
+	w.Flush()
+
+	if w.Code != http.StatusPreconditionFailed {
+		t.Errorf("got %d", w.Code)
+	}
+}

--- a/idempotent/lru/lru.go
+++ b/idempotent/lru/lru.go
@@ -30,6 +30,10 @@ type Mem struct {
 }
 
 func (m *Mem) SeenBefore(key string) bool {
+	if m == nil {
+		return false
+	}
+
 	seen := m.cache.Contains(key)
 	if !seen {
 		m.cache.Add(key, defaultValue)

--- a/idempotent/lru/lru_test.go
+++ b/idempotent/lru/lru_test.go
@@ -23,3 +23,14 @@ func TestLRU(t *testing.T) {
 		t.Errorf("expected not seen")
 	}
 }
+
+func TestLRU__nil(t *testing.T) {
+	var cache *Mem
+	if cache.SeenBefore("test") {
+		t.Error("nil - shouldn't mark as seen")
+	}
+	// "see" the same key again
+	if cache.SeenBefore("test") {
+		t.Error("nil - shouldn't mark as seen")
+	}
+}


### PR DESCRIPTION
This is a wrapper around http.ResponseWriter that optionally:
 - records response timings in a go-kit Histogram
 - emits a log line with request/response information iff X-Request-ID != ""
 - optionally 403's if X-User-Id isn't set

Fixes: https://github.com/moov-io/base/issues/3