### PR TITLE
http: enforce max header lengh of 36 UTF-8 characters

### DIFF
--- a/http/server.go
+++ b/http/server.go
@@ -13,8 +13,13 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/gorilla/mux"
+)
+
+const (
+	maxHeaderLength = 36
 )
 
 // Problem writes err to w while also setting the HTTP status code, content-type and marshaling
@@ -114,4 +119,11 @@ func GetRequestId(r *http.Request) string {
 // GetUserId returns the Moov userId from HTTP headers
 func GetUserId(r *http.Request) string {
 	return r.Header.Get("X-User-Id")
+}
+
+func truncate(s string) string {
+	if utf8.RuneCountInString(s) > maxHeaderLength {
+		return s[:maxHeaderLength]
+	}
+	return s
 }

--- a/http/server_test.go
+++ b/http/server_test.go
@@ -11,6 +11,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"unicode/utf8"
 
 	"github.com/gorilla/mux"
 )
@@ -97,5 +98,16 @@ func TestHTTP_InternalError(t *testing.T) {
 
 	if !strings.HasPrefix(where, "server_test.go") { // This will always be this file's name
 		t.Errorf("got %s", where)
+	}
+}
+
+func TestHTTP__truncate(t *testing.T) {
+	s1 := "1234567890123456789012345678901234567890" // 40 characters
+	s2 := truncate(s1)
+	if s1 == s2 {
+		t.Errorf("strings shouldn't match")
+	}
+	if n := utf8.RuneCountInString(s2); n != maxHeaderLength {
+		t.Errorf("s2 length is %d", n)
 	}
 }

--- a/idempotent/idempotent.go
+++ b/idempotent/idempotent.go
@@ -6,6 +6,12 @@ package idempotent
 
 import (
 	"net/http"
+	"unicode/utf8"
+)
+
+const (
+	// maxIdempotencyKeyLength is the longest X-Idempotency-Key string legnth allowed.
+	maxIdempotencyKeyLength = 36
 )
 
 // Recorder offers a method to determine if a given key has been
@@ -18,7 +24,7 @@ type Recorder interface {
 // FromRequest extracts the idempotency key from HTTP headers and records its presence in
 // the provided Recorder.
 func FromRequest(req *http.Request, rec Recorder) (key string, seen bool) {
-	key = req.Header.Get("X-Idempotency-Key")
+	key = truncate(req.Header.Get("X-Idempotency-Key"))
 	if key == "" {
 		return "", false
 	}
@@ -28,4 +34,11 @@ func FromRequest(req *http.Request, rec Recorder) (key string, seen bool) {
 // SeenBefore sets a HTTP response code as an error for previously seen idempotency keys.
 func SeenBefore(w http.ResponseWriter) {
 	w.WriteHeader(http.StatusPreconditionFailed)
+}
+
+func truncate(s string) string {
+	if utf8.RuneCountInString(s) > maxIdempotencyKeyLength {
+		return s[:maxIdempotencyKeyLength]
+	}
+	return s
 }

--- a/idempotent/idempotent_test.go
+++ b/idempotent/idempotent_test.go
@@ -1,0 +1,21 @@
+// Copyright 2018 The Moov Authors
+// Use of this source code is governed by an Apache License
+// license that can be found in the LICENSE file.
+
+package idempotent
+
+import (
+	"testing"
+	"unicode/utf8"
+)
+
+func TestIdempotent__truncate(t *testing.T) {
+	s1 := "1234567890123456789012345678901234567890" // 40 characters
+	s2 := truncate(s1)
+	if s1 == s2 {
+		t.Errorf("strings shouldn't match")
+	}
+	if n := utf8.RuneCountInString(s2); n != maxIdempotencyKeyLength {
+		t.Errorf("s2 length is %d", n)
+	}
+}


### PR DESCRIPTION
We aren't creating ID's longer than this limit so there's no reason to allow them. 36 characters is length of a UUID.

The default limit in Go is something like 10k characters, but we don't want those filling up log files. 