### PR TITLE
http: don't double record idempotency key

### DIFF
--- a/http/response.go
+++ b/http/response.go
@@ -104,7 +104,6 @@ func (w *ResponseWriter) ensureHeaders(rec idempotent.Recorder) error {
 		return ErrNoUserId
 	}
 	if _, seen := idempotent.FromRequest(w.request, rec); seen {
-		idempotent.SeenBefore(w)
 		return idempotent.ErrSeenBefore
 	}
 	return nil


### PR DESCRIPTION
`FromRequest` already marks the key as seen, so we don't need to double count. 