### PR TITLE
time: Add NewTime for wrapping time.Time

### DIFF
--- a/time.go
+++ b/time.go
@@ -27,6 +27,15 @@ func Now() Time {
 	}
 }
 
+// NewTime wraps a time.Time value in Moov's base.Time struct.
+// If you need the underlying time.Time value call .Time:
+//
+// now := Now()
+// fmt.Println(start.Sub(now.Time))
+func NewTime(t time.Time) Time {
+	return Time{t}
+}
+
 func (t Time) MarshalJSON() ([]byte, error) {
 	var bs []byte
 	bs = append(bs, '"')

--- a/time_test.go
+++ b/time_test.go
@@ -7,6 +7,7 @@ package base
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"os"
 	"os/exec"
 	"runtime"
@@ -24,6 +25,19 @@ func TestTime(t *testing.T) {
 	if tt := time.Now().Add(1 * time.Second); t1.Sub(tt) == 0 {
 		t.Error("expected difference in timing")
 	}
+}
+
+func TestTime__NewTime(t *testing.T) {
+	f := func(_ Time) {
+		return
+	}
+	f(NewTime(time.Now())) // make sure we can lift time.Time values
+
+	start := time.Now().Add(-1 * time.Second)
+
+	// Example from NewTime godoc
+	now := Now()
+	fmt.Println(start.Sub(now.Time))
 }
 
 func TestTime__JSON(t *testing.T) {


### PR DESCRIPTION
```Go
now := Now()
fmt.Println(start.Sub(now.Time))
```