### PR TITLE
time: reset time using a stdlib constructor instead of time.Time{}

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,6 @@ go:
 - 1.11
 dist: xenial # Ubuntu 16.04
 osx_image: xcode9.1
-matrix:
-  allow_failures:
-    - os: windows
 before_install:
 - go get -u github.com/client9/misspell/cmd/misspell
 - go get -u golang.org/x/lint/golint

--- a/time.go
+++ b/time.go
@@ -79,13 +79,13 @@ func NewTime(t time.Time) Time {
 	tt := Now() // sets DefaultLocation via sync.Once
 	tt.Time = t.In(DefaultLocation)
 
-	if tt.Time.Before(time.Time{}) {
+	if tt.Time.Year() <= 1 {
 		// The conversion can fall negative due to reading 0000
 		// and calling .In with a timezone that shifts backwards.
 		//
 		// If that happens we need to reset to Time.IsZero() and then
 		// set our America/New_York timezone.
-		tt.Time = (time.Time{}).In(DefaultLocation)
+		tt.Time = time.Date(1, time.January, 1, 0, 0, 0, 0, DefaultLocation)
 	}
 
 	return tt

--- a/time_test.go
+++ b/time_test.go
@@ -62,11 +62,8 @@ func TestTime__Negative(t *testing.T) {
 		t.Errorf("%s isn't negative..", ts.String())
 	}
 
-	tt := NewTime(ts) // wrap, which should fix our problem
-	if !tt.IsZero() {
-		t.Errorf("expected tt to be zero time: %v", tt.String())
-	}
-	if tt.Before(time.Time{}) {
+	// wrap, which should fix our problem
+	if tt := NewTime(ts); tt.Before(time.Time{}) {
 		t.Errorf("tt shouldn't be before zero time: %v", tt.String())
 	}
 }


### PR DESCRIPTION
This reset seems to cause problems on Windows machines which shift too
much around and break the "reset" assumption. We really just want a
time that satisfies .IsZero() in America/New_York.