### PR TITLE
time: convert new and incoming times (JSON) to UTC rather than America/New_York

### DIFF
--- a/time.go
+++ b/time.go
@@ -5,7 +5,6 @@
 package base
 
 import (
-	"sync"
 	"time"
 
 	"github.com/rickar/cal"
@@ -13,13 +12,6 @@ import (
 
 const (
 	iso8601Format = "2006-01-02T15:04:05Z07:00"
-)
-
-var (
-	// DefaultLocation is the *time.Location used when creating a BankTime instance.
-	// By default America/New_York is populated here.
-	DefaultLocation *time.Location
-	setup           sync.Once
 )
 
 // Time is an time.Time struct that encodes and decodes in ISO 8601.
@@ -51,21 +43,10 @@ func Now() Time {
 	cal.AddUsHolidays(calendar)
 	calendar.Observed = cal.ObservedMonday
 
-	loc := getNYCLocation()
-
 	return Time{
 		cal:  calendar,
-		Time: time.Now().In(loc).Truncate(1 * time.Second),
+		Time: time.Now().UTC().Truncate(1 * time.Second),
 	}
-}
-
-func getNYCLocation() *time.Location {
-	loc := DefaultLocation
-	setup.Do(func() {
-		loc, _ = time.LoadLocation("America/New_York")
-		DefaultLocation = loc
-	})
-	return loc
 }
 
 // NewTime wraps a time.Time value in Moov's base.Time struct.
@@ -76,18 +57,8 @@ func getNYCLocation() *time.Location {
 // now := Now()
 // fmt.Println(start.Sub(now.Time))
 func NewTime(t time.Time) Time {
-	tt := Now() // sets DefaultLocation via sync.Once
-	tt.Time = t.In(DefaultLocation)
-
-	if tt.Time.Before(time.Time{}) {
-		// The conversion can fall negative due to reading 0000
-		// and calling .In with a timezone that shifts backwards.
-		//
-		// If that happens we need to reset to Time.IsZero() and then
-		// set our America/New_York timezone.
-		tt.Time = (time.Time{}).In(DefaultLocation)
-	}
-
+	tt := Now()
+	tt.Time = t.UTC() // overwrite underlying Time
 	return tt
 }
 
@@ -114,8 +85,7 @@ func (t *Time) UnmarshalJSON(data []byte) error {
 		*t = NewTime(tt)
 	}
 
-	loc := getNYCLocation()
-	t.Time = tt.In(loc).Truncate(1 * time.Second) // convert to our location and drop millis
+	t.Time = tt.UTC().Truncate(1 * time.Second) // convert to UTC and drop millis
 
 	return nil
 }

--- a/time_test.go
+++ b/time_test.go
@@ -47,30 +47,6 @@ func TestTime__NewTime(t *testing.T) {
 	fmt.Println(start.Sub(now.Time))
 }
 
-func TestTime__Negative(t *testing.T) {
-	loc, err := time.LoadLocation("America/New_York")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// ts is 000000 (yymmdd) and 0000 (hhmm) from an ACH file,
-	// then we convert to NYC timezone
-	ts := time.Date(0, time.January, 0, 0, 0, 0, 0, time.UTC).In(loc)
-
-	if !ts.Before(time.Time{}) {
-		// ts should be negative now (i.e. -0001-12-30 19:03:58 -0456 LMT), which is bogus
-		t.Errorf("%s isn't negative..", ts.String())
-	}
-
-	tt := NewTime(ts) // wrap, which should fix our problem
-	if !tt.IsZero() {
-		t.Errorf("expected tt to be zero time: %v", tt.String())
-	}
-	if tt.Before(time.Time{}) {
-		t.Errorf("tt shouldn't be before zero time: %v", tt.String())
-	}
-}
-
 func TestTime__JSON(t *testing.T) {
 	// marshal and then unmarshal
 	t1 := Now()
@@ -128,7 +104,7 @@ func TestTime__javascript(t *testing.T) {
 	if err := json.Unmarshal(in, &wrap); err != nil {
 		t.Fatal(err)
 	}
-	if v := wrap.When.String(); v != "2018-12-14 15:36:58 -0500 EST" {
+	if v := wrap.When.String(); v != "2018-12-14 20:36:58 +0000 UTC" {
 		t.Errorf("got %q", v)
 	}
 }


### PR DESCRIPTION
Reverts https://github.com/moov-io/base/pull/28 and the timezone changes. 