### PR TITLE
Move Has and Match functions to base

### DIFF
--- a/error_test.go
+++ b/error_test.go
@@ -133,3 +133,57 @@ func TestErrorList_MarshalJSON(t *testing.T) {
 		t.Errorf("got %s", errorList.Error())
 	}
 }
+
+// testMatch validates the Match error function
+func TestMatch(t *testing.T) {
+	testError := errors.New("Test error")
+
+	if !Match(nil, nil) {
+		t.Error("Match should be reflexive on nil")
+	}
+
+	if !Match(testError, testError) {
+		t.Error("Match should be reflexive")
+	}
+
+	p := ParseError{Err: testError}
+	if !Match(p, testError) {
+		t.Error("Match should match wrapped errors implementing the UnwrappableError interface")
+	}
+
+	differentError := errors.New("Different error")
+	if Match(testError, differentError) {
+		t.Error("Match should return false for different simple errors")
+	}
+
+	q := ParseError{Err: differentError}
+	if !Match(p, q) {
+		t.Error("Match should match two different ParseErrors to each other since they have the same type")
+	}
+
+	errorList := ErrorList{}
+	if Match(errorList, p) {
+		t.Error("Match should return false for errors with different types")
+	}
+}
+
+// testHas validates the Has error function
+func TestHas(t *testing.T) {
+	err := errors.New("Non list error")
+
+	if Has(err, err) {
+		t.Error("Has should return false when given a non-list error as the first arg")
+	}
+
+	if Has(nil, err) {
+		t.Error("Has should not return true if there are no errors")
+	}
+
+	if Has(ErrorList([]error{}), err) {
+		t.Error("Has should not return true if there are no errors")
+	}
+
+	if !Has(ErrorList([]error{err}), err) {
+		t.Error("Has should return true if the error list has the test error")
+	}
+}


### PR DESCRIPTION
This moves the Has and Match functions for type-based error handling to base. I've also added complete test coverage for these functions.

I had to modify the Match function to be able to unwrap errors more gracefully. The new version uses an interface `UnwrappableError` with an `Unwrap` method so that various wrapped error type (e.g. ParseError, BatchError) can easily be handled by Match simply by adding an additional method. 