### PR TITLE
time: expose ISO 8601 format

### DIFF
--- a/time.go
+++ b/time.go
@@ -11,7 +11,8 @@ import (
 )
 
 const (
-	iso8601Format = "2006-01-02T15:04:05Z07:00"
+	// ISO8601Format represents an ISO 8601 format with timezone
+	ISO8601Format = "2006-01-02T15:04:05Z07:00"
 )
 
 // Time is an time.Time struct that encodes and decodes in ISO 8601.
@@ -67,7 +68,7 @@ func (t Time) MarshalJSON() ([]byte, error) {
 	bs = append(bs, '"')
 
 	t.Time = t.Time.Truncate(1 * time.Second) // drop milliseconds
-	bs = t.AppendFormat(bs, iso8601Format)
+	bs = t.AppendFormat(bs, ISO8601Format)
 
 	bs = append(bs, '"')
 	return bs, nil
@@ -78,7 +79,7 @@ func (t *Time) UnmarshalJSON(data []byte) error {
 	if string(data) == "null" {
 		return nil
 	}
-	tt, err := time.Parse(`"`+iso8601Format+`"`, string(data))
+	tt, err := time.Parse(`"`+ISO8601Format+`"`, string(data))
 	if err != nil || tt.IsZero() {
 		// Try in RFC3339 format (default Go time)
 		tt, _ = time.Parse(time.RFC3339, string(data))

--- a/time_test.go
+++ b/time_test.go
@@ -126,7 +126,7 @@ func TestTime__ruby(t *testing.T) {
 		}
 	}
 
-	tt, err := time.Parse(iso8601Format, "2018-11-18T09:04:23-08:00")
+	tt, err := time.Parse(ISO8601Format, "2018-11-18T09:04:23-08:00")
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
For https://github.com/moov-io/ach/issues/556 we're going to expose the format to allow ACH to parse. 