### PR TITLE
add stime pkg from moov-io/identity`

### DIFF
--- a/stime/static_time.go
+++ b/stime/static_time.go
@@ -1,0 +1,36 @@
+package stime
+
+import (
+	"time"
+)
+
+type StaticTimeService interface {
+	Change(update time.Time) time.Time
+	Add(d time.Duration) time.Time
+	TimeService
+}
+
+type staticTimeService struct {
+	time time.Time
+}
+
+func NewStaticTimeService() StaticTimeService {
+	return &staticTimeService{
+		time: time.Now().In(time.UTC).Round(time.Second),
+	}
+}
+
+// DeleteInvite - Delete an invite that was sent and invalidate the token.
+func (s *staticTimeService) Now() time.Time {
+	return s.time
+}
+
+func (s *staticTimeService) Change(update time.Time) time.Time {
+	s.time = update
+	return s.time
+}
+
+func (s *staticTimeService) Add(d time.Duration) time.Time {
+	s.time = s.time.Add(d)
+	return s.time
+}

--- a/stime/system_time.go
+++ b/stime/system_time.go
@@ -1,0 +1,20 @@
+package stime
+
+import (
+	"time"
+)
+
+type TimeService interface {
+	Now() time.Time
+}
+
+type timeService struct{}
+
+func NewSystemTimeService() TimeService {
+	return &timeService{}
+}
+
+// DeleteInvite - Delete an invite that was sent and invalidate the token.
+func (s *timeService) Now() time.Time {
+	return time.Now().In(time.UTC)
+}


### PR DESCRIPTION
I suggest we rename `stime` to `timetest` to indicate that this package should only be used in testing; similar to `net/httptest`. Let me know what you think.

Related issue https://github.com/moov-io/identity/issues/60
