### PR TITLE
accept variable number of key, val in log.WithKeyValue

### DIFF
--- a/log/logger.go
+++ b/log/logger.go
@@ -13,7 +13,7 @@ import (
 type Logger interface {
 	With(ctxs ...Context) Logger
 	WithMap(mapCtx map[string]string) Logger
-	WithKeyValue(key, value string) Logger
+	WithKeyValue(keyvals ...string) Logger
 
 	Info() Logger
 	Error() Logger
@@ -94,10 +94,25 @@ func (l *logger) WithMap(mapCtx map[string]string) Logger {
 	}
 }
 
-func (l *logger) WithKeyValue(key, value string) Logger {
-	return l.WithMap(map[string]string{
-		key: value,
-	})
+func (l *logger) WithKeyValue(keyvals ...string) Logger {
+	input := map[string]string{}
+
+	if len(keyvals)%2 != 0 {
+		keyvals = append(keyvals, log.ErrMissingValue.Error())
+	}
+
+	// split into key/value pars
+	for i, key := range keyvals {
+		// skip for values as they have odd index
+		if i%2 != 0 {
+			continue
+		}
+
+		value := keyvals[i+1]
+		input[key] = value
+	}
+
+	return l.WithMap(input)
 }
 
 func (l *logger) Info() Logger {

--- a/log/logger.go
+++ b/log/logger.go
@@ -102,14 +102,8 @@ func (l *logger) WithKeyValue(keyvals ...string) Logger {
 	}
 
 	// split into key/value pars
-	for i, key := range keyvals {
-		// skip for values as they have odd index
-		if i%2 != 0 {
-			continue
-		}
-
-		value := keyvals[i+1]
-		input[key] = value
+	for i := 0; i < len(keyvals); i += 2 {
+		input[keyvals[i]] = keyvals[i+1]
 	}
 
 	return l.WithMap(input)

--- a/log/logger_test.go
+++ b/log/logger_test.go
@@ -77,6 +77,12 @@ func Test_CustomKeyValue(t *testing.T) {
 	log.WithKeyValue("custom", "value").Log("test")
 
 	a.Contains(buffer.String(), "custom=value")
+
+	log.WithKeyValue("one", "1", "two", "2", "three").Log("test")
+
+	a.Contains(buffer.String(), "one=1")
+	a.Contains(buffer.String(), "two=2")
+	a.Contains(buffer.String(), "three=(MISSING)")
 }
 
 func Test_CustomMap(t *testing.T) {


### PR DESCRIPTION
at least I need this change to replace go-kit/log with base/log here: https://github.com/moov-io/base/blob/master/http/response.go#L61