### PR TITLE
Revert "accept variable number of key, val in log.WithKeyValue"

### DIFF
--- a/log/logger.go
+++ b/log/logger.go
@@ -13,7 +13,7 @@ import (
 type Logger interface {
 	With(ctxs ...Context) Logger
 	WithMap(mapCtx map[string]string) Logger
-	WithKeyValue(keyvals ...string) Logger
+	WithKeyValue(key, value string) Logger
 
 	Info() Logger
 	Error() Logger
@@ -98,19 +98,10 @@ func (l *logger) WithMap(mapCtx map[string]string) Logger {
 	}
 }
 
-func (l *logger) WithKeyValue(keyvals ...string) Logger {
-	input := map[string]string{}
-
-	if len(keyvals)%2 != 0 {
-		keyvals = append(keyvals, log.ErrMissingValue.Error())
-	}
-
-	// split into key/value pars
-	for i := 0; i < len(keyvals); i += 2 {
-		input[keyvals[i]] = keyvals[i+1]
-	}
-
-	return l.WithMap(input)
+func (l *logger) WithKeyValue(key, value string) Logger {
+	return l.WithMap(map[string]string{
+		key: value,
+	})
 }
 
 func (l *logger) Info() Logger {

--- a/log/logger_test.go
+++ b/log/logger_test.go
@@ -78,12 +78,6 @@ func Test_CustomKeyValue(t *testing.T) {
 	log.WithKeyValue("custom", "value").Log("test")
 
 	a.Contains(buffer.String(), "custom=value")
-
-	log.WithKeyValue("one", "1", "two", "2", "three").Log("test")
-
-	a.Contains(buffer.String(), "one=1")
-	a.Contains(buffer.String(), "two=2")
-	a.Contains(buffer.String(), "three=(MISSING)")
 }
 
 func Test_CustomMap(t *testing.T) {


### PR DESCRIPTION
Reverts moov-io/base#92

Motivation for this revert is to reduce the chance of passing wrong amount of arguments to the method and getting broken logs. As example,

```go
log.WithKeyValue("one", "1", "two", "2", "three", "3")
```
Say you miss the "1" in that line and now your indexes are all off. You'd end up with "one=two" "2=three" in logs. 

Versus with fixed number of arguments (this PR) you are constrainted by the compiler to not mess it up:

```go
log.WithKeyValue("one", "1").WithKeyValue("two", "2")
```
Also, if you try to add 3 like this:

```go
log.WithKeyValue("three", ) 
```
it would compiler error.

Based on discussion with @InfernoJJ 