### PR TITLE
base: add Logf method to logger

### DIFF
--- a/log/logger.go
+++ b/log/logger.go
@@ -20,6 +20,7 @@ type Logger interface {
 	Fatal() Logger
 
 	Log(msg string)
+	Logf(format string, a ...interface{})
 	LogError(msg string, err error) error
 	LogErrorF(format string, a ...interface{}) error
 }
@@ -149,6 +150,11 @@ func (l *logger) Log(msg string) {
 	}
 
 	l.writer.Log(keyvals...)
+}
+
+func (l *logger) Logf(format string, a ...interface{}) {
+	message := fmt.Sprintf(format, a...)
+	l.Log(message)
 }
 
 // LogError logs the error or creates a new one using the msg if `err` is nil and returns it.

--- a/log/logger_test.go
+++ b/log/logger_test.go
@@ -23,6 +23,15 @@ func Test_Log(t *testing.T) {
 	a.Contains(buffer.String(), "level=info")
 }
 
+func Test_Logf(t *testing.T) {
+	a, buffer, log := Setup(t)
+
+	log.Logf("my message: %s", "hello")
+
+	a.Contains(buffer.String(), "my message: hello")
+	a.Contains(buffer.String(), "level=info")
+}
+
 func Test_WithContext(t *testing.T) {
 	a, buffer, log := Setup(t)
 


### PR DESCRIPTION
Replacing logger in Customer (`go-kit/log` -> `base/log`) I face a lot of such use cases:

```go
logger.Log(fmt.Sprintf("updating address=%s for customer=%s", addressId, customerID))
```

`base/log` supports LogErrorF method, I think that it may be convenient and consistent to add Logf method to replace above with:
```go
logger.Log("updating address=%s for customer=%s", addressId, customerID)
```

I also think we should rename `LogErrorF` into `LogErrorf`. I can do this in separate PR. No one is using `base/log` now, so when Identity and other projects will switch to `base/log` developers will rename method. Thoughts?