### PR TITLE
Database fixes

### DIFF
--- a/database/database.go
+++ b/database/database.go
@@ -38,10 +38,8 @@ func NewAndMigrate(config DatabaseConfig, logger log.Logger, ctx context.Context
 		db.Close()
 	}
 
-	if config.migrationsDir != "" {
-		if err = RunMigrations(logger, db, config); err != nil {
-			return nil, shutdown, err
-		}
+	if err = RunMigrations(logger, db, config); err != nil {
+		return nil, shutdown, err
 	}
 
 	return db, shutdown, nil

--- a/database/database.go
+++ b/database/database.go
@@ -21,7 +21,7 @@ func New(ctx context.Context, logger log.Logger, config DatabaseConfig) (*sql.DB
 }
 
 // TODO remove shutdown method to make it consistent with New(...) *sql.DB, error
-func NewAndMigrate(config DatabaseConfig, logger log.Logger, ctx context.Context) (*sql.DB, error) {
+func NewAndMigrate(ctx context.Context, logger log.Logger, config DatabaseConfig) (*sql.DB, error) {
 	if logger == nil {
 		logger = log.NewNopLogger()
 	}

--- a/database/database.go
+++ b/database/database.go
@@ -20,7 +20,6 @@ func New(ctx context.Context, logger log.Logger, config DatabaseConfig) (*sql.DB
 	return nil, fmt.Errorf("database config not defined")
 }
 
-// TODO remove shutdown method to make it consistent with New(...) *sql.DB, error
 func NewAndMigrate(ctx context.Context, logger log.Logger, config DatabaseConfig) (*sql.DB, error) {
 	if logger == nil {
 		logger = log.NewNopLogger()

--- a/database/database.go
+++ b/database/database.go
@@ -11,8 +11,8 @@ import (
 // New establishes a database connection according to the type and environmental
 // variables for that specific database.
 func New(ctx context.Context, logger log.Logger, config DatabaseConfig) (*sql.DB, error) {
-	if config.MySql != nil {
-		return mysqlConnection(logger, config.MySql.User, config.MySql.Password, config.MySql.Address, config.DatabaseName).Connect(ctx)
+	if config.MySQL != nil {
+		return mysqlConnection(logger, config.MySQL.User, config.MySQL.Password, config.MySQL.Address, config.DatabaseName).Connect(ctx)
 	} else if config.SQLite != nil {
 		return sqliteConnection(logger, config.SQLite.Path).Connect(ctx)
 	}

--- a/database/database.go
+++ b/database/database.go
@@ -13,8 +13,8 @@ import (
 func New(ctx context.Context, logger log.Logger, config DatabaseConfig) (*sql.DB, error) {
 	if config.MySql != nil {
 		return mysqlConnection(logger, config.MySql.User, config.MySql.Password, config.MySql.Address, config.DatabaseName).Connect(ctx)
-	} else if config.SqlLite != nil {
-		return sqliteConnection(logger, config.SqlLite.Path).Connect(ctx)
+	} else if config.SQLite != nil {
+		return sqliteConnection(logger, config.SQLite.Path).Connect(ctx)
 	}
 
 	return nil, fmt.Errorf("database config not defined")

--- a/database/database.go
+++ b/database/database.go
@@ -21,7 +21,7 @@ func New(ctx context.Context, logger log.Logger, config DatabaseConfig) (*sql.DB
 }
 
 // TODO remove shutdown method to make it consistent with New(...) *sql.DB, error
-func NewAndMigrate(config DatabaseConfig, logger log.Logger, ctx context.Context) (*sql.DB, func(), error) {
+func NewAndMigrate(config DatabaseConfig, logger log.Logger, ctx context.Context) (*sql.DB, error) {
 	if logger == nil {
 		logger = log.NewNopLogger()
 	}
@@ -32,20 +32,16 @@ func NewAndMigrate(config DatabaseConfig, logger log.Logger, ctx context.Context
 
 	// run migrations first
 	if err := RunMigrations(logger, config); err != nil {
-		return nil, func() {}, err
+		return nil, err
 	}
 
 	// create DB connection for our service
 	db, err := New(ctx, logger, config)
 	if err != nil {
-		return nil, func() {}, err
+		return nil, err
 	}
 
-	shutdown := func() {
-		db.Close()
-	}
-
-	return db, shutdown, nil
+	return db, nil
 }
 
 // UniqueViolation returns true when the provided error matches a database error

--- a/database/database_test.go
+++ b/database/database_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func Test_NewAndMigration_SQLite3(t *testing.T) {
-	db, err := NewAndMigrate(InMemorySqliteConfig, nil, nil)
+	db, err := NewAndMigrate(nil, nil, InMemorySqliteConfig)
 	if err != nil {
 		t.FailNow()
 	}
@@ -26,7 +26,7 @@ func Test_NewAndMigration_MySql(t *testing.T) {
 	}
 	defer container.Close()
 
-	db, err := NewAndMigrate(*config, nil, nil)
+	db, err := NewAndMigrate(nil, nil, *config)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/database/database_test.go
+++ b/database/database_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/moov-io/base/docker"
 )
 
-func Test_NewAndMigration_SqlLite3(t *testing.T) {
+func Test_NewAndMigration_SQLite3(t *testing.T) {
 	_, close, err := NewAndMigrate(InMemorySqliteConfig, nil, nil)
 	if err != nil {
 		t.FailNow()

--- a/database/database_test.go
+++ b/database/database_test.go
@@ -8,11 +8,11 @@ import (
 )
 
 func Test_NewAndMigration_SQLite3(t *testing.T) {
-	_, close, err := NewAndMigrate(InMemorySqliteConfig, nil, nil)
+	db, err := NewAndMigrate(InMemorySqliteConfig, nil, nil)
 	if err != nil {
 		t.FailNow()
 	}
-	close()
+	db.Close()
 }
 
 func Test_NewAndMigration_MySql(t *testing.T) {
@@ -26,11 +26,11 @@ func Test_NewAndMigration_MySql(t *testing.T) {
 	}
 	defer container.Close()
 
-	_, close, err := NewAndMigrate(*config, nil, nil)
+	db, err := NewAndMigrate(*config, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
-	close()
+	db.Close()
 }
 
 func TestUniqueViolation(t *testing.T) {

--- a/database/database_test.go
+++ b/database/database_test.go
@@ -1,6 +1,7 @@
 package database
 
 import (
+	"context"
 	"errors"
 	"testing"
 
@@ -8,7 +9,7 @@ import (
 )
 
 func Test_NewAndMigration_SQLite3(t *testing.T) {
-	db, err := NewAndMigrate(nil, nil, InMemorySqliteConfig)
+	db, err := NewAndMigrate(context.Background(), nil, InMemorySqliteConfig)
 	if err != nil {
 		t.FailNow()
 	}
@@ -26,7 +27,7 @@ func Test_NewAndMigration_MySql(t *testing.T) {
 	}
 	defer container.Close()
 
-	db, err := NewAndMigrate(nil, nil, *config)
+	db, err := NewAndMigrate(context.Background(), nil, *config)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/database/migrator.go
+++ b/database/migrator.go
@@ -55,19 +55,19 @@ func RunMigrations(logger log.Logger, config DatabaseConfig) error {
 }
 
 func GetDriver(db *sql.DB, config DatabaseConfig) (database.Driver, error) {
-	if config.MySql != nil {
-		return MySqlDriver(db)
+	if config.MySQL != nil {
+		return MySQLDriver(db)
 	} else if config.SQLite != nil {
-		return Sqlite3Driver(db)
+		return SQLite3Driver(db)
 	}
 
 	return nil, fmt.Errorf("database config not defined")
 }
 
-func MySqlDriver(db *sql.DB) (database.Driver, error) {
+func MySQLDriver(db *sql.DB) (database.Driver, error) {
 	return migmysql.WithInstance(db, &migmysql.Config{})
 }
 
-func Sqlite3Driver(db *sql.DB) (database.Driver, error) {
+func SQLite3Driver(db *sql.DB) (database.Driver, error) {
 	return migsqlite3.WithInstance(db, &migsqlite3.Config{})
 }

--- a/database/migrator.go
+++ b/database/migrator.go
@@ -50,7 +50,7 @@ func RunMigrations(logger log.Logger, db *sql.DB, config DatabaseConfig) error {
 func GetDriver(db *sql.DB, config DatabaseConfig) (database.Driver, error) {
 	if config.MySql != nil {
 		return MySqlDriver(db)
-	} else if config.SqlLite != nil {
+	} else if config.SQLite != nil {
 		return Sqlite3Driver(db)
 	}
 

--- a/database/migrator.go
+++ b/database/migrator.go
@@ -1,6 +1,7 @@
 package database
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 
@@ -14,7 +15,13 @@ import (
 	"github.com/moov-io/base/log"
 )
 
-func RunMigrations(logger log.Logger, db *sql.DB, config DatabaseConfig) error {
+func RunMigrations(logger log.Logger, config DatabaseConfig) error {
+	db, err := New(context.Background(), logger, config)
+	if err != nil {
+		return err
+	}
+	defer db.Close()
+
 	logger.Info().Log("Running Migrations")
 
 	_ = pkger.Include("/migrations/")
@@ -37,12 +44,12 @@ func RunMigrations(logger log.Logger, db *sql.DB, config DatabaseConfig) error {
 	switch err {
 	case nil:
 	case migrate.ErrNoChange:
-		logger.Info().Logf("Database already at version")
+		logger.Info().Log("Database already at version")
 	default:
 		return logger.Fatal().LogErrorf("Error running migrations: %w", err).Err()
 	}
 
-	logger.Info().Logf("Migrations complete")
+	logger.Info().Log("Migrations complete")
 
 	return nil
 }

--- a/database/migrator.go
+++ b/database/migrator.go
@@ -3,7 +3,6 @@ package database
 import (
 	"database/sql"
 	"fmt"
-	"os"
 
 	"github.com/golang-migrate/migrate/v4"
 	"github.com/golang-migrate/migrate/v4/database"
@@ -16,12 +15,9 @@ import (
 )
 
 func RunMigrations(logger log.Logger, db *sql.DB, config DatabaseConfig) error {
-	if _, err := os.Stat(config.migrationsDir); os.IsNotExist(err) {
-		return fmt.Errorf("migrations directory=\"%s\" does not exist", config.migrationsDir)
-	}
+	logger.Info().Log("Running Migrations")
 
-	logger.Info().Logf("Running Migrations")
-	_ = pkger.Include(config.migrationsDir)
+	_ = pkger.Include("/migrations/")
 
 	driver, err := GetDriver(db, config)
 	if err != nil {
@@ -29,7 +25,7 @@ func RunMigrations(logger log.Logger, db *sql.DB, config DatabaseConfig) error {
 	}
 
 	m, err := migrate.NewWithDatabaseInstance(
-		fmt.Sprintf("pkger://%s", config.migrationsDir),
+		"pkger:///migrations/",
 		config.DatabaseName,
 		driver,
 	)

--- a/database/model_config.go
+++ b/database/model_config.go
@@ -1,10 +1,9 @@
 package database
 
 type DatabaseConfig struct {
-	MySql         *MySqlConfig
-	SqlLite       *SqlLiteConfig
-	DatabaseName  string
-	migrationsDir string
+	MySql        *MySqlConfig
+	SqlLite      *SqlLiteConfig
+	DatabaseName string
 }
 
 type MySqlConfig struct {

--- a/database/model_config.go
+++ b/database/model_config.go
@@ -2,7 +2,7 @@ package database
 
 type DatabaseConfig struct {
 	MySql        *MySqlConfig
-	SqlLite      *SqlLiteConfig
+	SQLite      *SQLiteConfig
 	DatabaseName string
 }
 
@@ -12,13 +12,13 @@ type MySqlConfig struct {
 	Password string
 }
 
-type SqlLiteConfig struct {
+type SQLiteConfig struct {
 	Path string
 }
 
 var InMemorySqliteConfig = DatabaseConfig{
 	DatabaseName: "sqlite",
-	SqlLite: &SqlLiteConfig{
+	SQLite: &SQLiteConfig{
 		Path: ":memory:",
 	},
 }

--- a/database/model_config.go
+++ b/database/model_config.go
@@ -1,12 +1,12 @@
 package database
 
 type DatabaseConfig struct {
-	MySql        *MySqlConfig
-	SQLite      *SQLiteConfig
+	MySQL        *MySQLConfig
+	SQLite       *SQLiteConfig
 	DatabaseName string
 }
 
-type MySqlConfig struct {
+type MySQLConfig struct {
 	Address  string
 	User     string
 	Password string

--- a/database/mysql.go
+++ b/database/mysql.go
@@ -126,14 +126,12 @@ func (r *TestMySQLDB) Close() error {
 
 	err := r.DB.Close()
 	if err != nil {
-		fmt.Println("Failed to close MySQL database")
-		panic(err)
+		return err
 	}
 
 	err = r.container.Close()
 	if err != nil {
-		fmt.Println("Failed to close MySQL docker container")
-		panic(err)
+		return err
 	}
 
 	return nil

--- a/database/mysql.go
+++ b/database/mysql.go
@@ -153,7 +153,7 @@ func CreateTestMySQLDB(t *testing.T) *TestMySQLDB {
 
 	ctx, cancelFunc := context.WithCancel(context.Background())
 
-	db, err := NewAndMigrate(*config, logger, ctx)
+	db, err := NewAndMigrate(ctx, logger, *config)
 	if err != nil {
 		container.Close()
 		t.Fatal(err)
@@ -162,12 +162,7 @@ func CreateTestMySQLDB(t *testing.T) *TestMySQLDB {
 	// Don't allow idle connections so we can verify all are closed at the end of testing
 	db.SetMaxIdleConns(0)
 
-	shutdownFunc := func() {
-		cancelFunc()
-		db.Close()
-	}
-
-	return &TestMySQLDB{DB: db, container: container, shutdown: shutdownFunc}
+	return &TestMySQLDB{DB: db, container: container, shutdown: cancelFunc}
 }
 
 func RunMySQLDockerInstance(config *DatabaseConfig) (*DatabaseConfig, *dockertest.Resource, error) {

--- a/database/mysql.go
+++ b/database/mysql.go
@@ -170,16 +170,16 @@ func RunMySQLDockerInstance(config *DatabaseConfig) (*DatabaseConfig, *dockertes
 		config.DatabaseName = "test"
 	}
 
-	if config.MySql == nil {
-		config.MySql = &MySqlConfig{}
+	if config.MySQL == nil {
+		config.MySQL = &MySQLConfig{}
 	}
 
-	if config.MySql.User == "" {
-		config.MySql.User = "moov"
+	if config.MySQL.User == "" {
+		config.MySQL.User = "moov"
 	}
 
-	if config.MySql.Password == "" {
-		config.MySql.Password = "secret"
+	if config.MySQL.Password == "" {
+		config.MySQL.Password = "secret"
 	}
 
 	pool, err := dockertest.NewPool("")
@@ -191,8 +191,8 @@ func RunMySQLDockerInstance(config *DatabaseConfig) (*DatabaseConfig, *dockertes
 		Repository: "mysql",
 		Tag:        "8",
 		Env: []string{
-			fmt.Sprintf("MYSQL_USER=%s", config.MySql.User),
-			fmt.Sprintf("MYSQL_PASSWORD=%s", config.MySql.Password),
+			fmt.Sprintf("MYSQL_USER=%s", config.MySQL.User),
+			fmt.Sprintf("MYSQL_PASSWORD=%s", config.MySQL.Password),
 			"MYSQL_ROOT_PASSWORD=secret",
 			fmt.Sprintf("MYSQL_DATABASE=%s", config.DatabaseName),
 		},
@@ -206,8 +206,8 @@ func RunMySQLDockerInstance(config *DatabaseConfig) (*DatabaseConfig, *dockertes
 
 	address := fmt.Sprintf("tcp(localhost:%s)", resource.GetPort("3306/tcp"))
 	dbURL := fmt.Sprintf("%s:%s@%s/%s",
-		config.MySql.User,
-		config.MySql.Password,
+		config.MySQL.User,
+		config.MySQL.Password,
 		address,
 		config.DatabaseName,
 	)
@@ -227,10 +227,10 @@ func RunMySQLDockerInstance(config *DatabaseConfig) (*DatabaseConfig, *dockertes
 
 	return &DatabaseConfig{
 		DatabaseName: config.DatabaseName,
-		MySql: &MySqlConfig{
+		MySQL: &MySQLConfig{
 			Address:  address,
-			User:     config.MySql.User,
-			Password: config.MySql.Password,
+			User:     config.MySQL.User,
+			Password: config.MySQL.Password,
 		},
 	}, resource, nil
 }

--- a/database/mysql.go
+++ b/database/mysql.go
@@ -208,10 +208,9 @@ func RunMySQLDockerInstance(config *DatabaseConfig) (*DatabaseConfig, *dockertes
 			"MYSQL_ROOT_PASSWORD=secret",
 			fmt.Sprintf("MYSQL_DATABASE=%s", config.DatabaseName),
 		},
+	}, func(dockerConfig *dc.HostConfig) {
+		dockerConfig.AutoRemove = true
 	},
-		func(dockerConfig *dc.HostConfig) {
-			dockerConfig.AutoRemove = true
-		},
 	)
 	if err != nil {
 		return nil, nil, err

--- a/database/mysql_test.go
+++ b/database/mysql_test.go
@@ -6,15 +6,17 @@ import (
 	"testing"
 
 	"github.com/moov-io/base/log"
+	"github.com/stretchr/testify/require"
 )
 
 func TestMySQL__basic(t *testing.T) {
 	db := CreateTestMySQLDB(t)
 	defer db.Close()
 
-	if err := db.DB.Ping(); err != nil {
-		t.Fatal(err)
-	}
+	err := db.DB.Ping()
+	require.NoError(t, err)
+
+	require.Equal(t, 0, db.DB.Stats().OpenConnections)
 
 	// create a phony MySQL
 	m := mysqlConnection(log.NewNopLogger(), "user", "pass", "127.0.0.1:3006", "db")
@@ -27,9 +29,8 @@ func TestMySQL__basic(t *testing.T) {
 			conn.Close()
 		}
 	}()
-	if conn != nil || err == nil {
-		t.Fatalf("conn=%#v expected error", conn)
-	}
+	require.Nil(t, conn)
+	require.Error(t, err)
 
 	cancelFunc()
 }

--- a/database/sqlite.go
+++ b/database/sqlite.go
@@ -126,7 +126,7 @@ func CreateTestSqliteDB(t *testing.T) *TestSQLiteDB {
 		t.Fatalf("sqlite test: %v", err)
 	}
 
-	err = RunMigrations(logger, db, DatabaseConfig{SqlLite: &SqlLiteConfig{}})
+	err = RunMigrations(logger, db, DatabaseConfig{SQLite: &SQLiteConfig{}})
 	if err != nil {
 		t.Fatalf("sqlite test: %v", err)
 	}

--- a/database/sqlite.go
+++ b/database/sqlite.go
@@ -129,7 +129,15 @@ func CreateTestSqliteDB(t *testing.T) *TestSQLiteDB {
 
 	ctx, cancelFunc := context.WithCancel(context.Background())
 
-	db, err := sqliteConnection(log.NewNopLogger(), filepath.Join(dir, "paygate.db")).Connect(ctx)
+	// logger = log.NewNopLogger()
+	logger := log.NewDefaultLogger()
+
+	db, err := sqliteConnection(logger, filepath.Join(dir, "paygate.db")).Connect(ctx)
+	if err != nil {
+		t.Fatalf("sqlite test: %v", err)
+	}
+
+	err = RunMigrations(logger, db, DatabaseConfig{SqlLite: &SqlLiteConfig{}})
 	if err != nil {
 		t.Fatalf("sqlite test: %v", err)
 	}
@@ -138,6 +146,7 @@ func CreateTestSqliteDB(t *testing.T) *TestSQLiteDB {
 	db.SetMaxIdleConns(0)
 
 	return &TestSQLiteDB{DB: db, dir: dir, shutdown: cancelFunc}
+
 }
 
 // SqliteUniqueViolation returns true when the provided error matches the SQLite error

--- a/database/sqlite.go
+++ b/database/sqlite.go
@@ -119,8 +119,7 @@ func CreateTestSqliteDB(t *testing.T) *TestSQLiteDB {
 
 	ctx, cancelFunc := context.WithCancel(context.Background())
 
-	// logger = log.NewNopLogger()
-	logger := log.NewDefaultLogger()
+	logger := log.NewNopLogger()
 
 	db, err := sqliteConnection(logger, filepath.Join(dir, "tests.db")).Connect(ctx)
 	if err != nil {

--- a/database/sqlite.go
+++ b/database/sqlite.go
@@ -84,16 +84,6 @@ func sqliteConnection(logger log.Logger, path string) *sqlite {
 	}
 }
 
-func getSqlitePath() string {
-	path := os.Getenv("SQLITE_DB_PATH")
-	if path == "" || strings.Contains(path, "..") {
-		// set default if empty or trying to escape
-		// don't filepath.ABS to avoid full-fs reads
-		path = "paygate.db"
-	}
-	return path
-}
-
 // TestSQLiteDB is a wrapper around sql.DB for SQLite connections designed for tests to provide
 // a clean database for each testcase.  Callers should cleanup with Close() when finished.
 type TestSQLiteDB struct {

--- a/database/sqlite.go
+++ b/database/sqlite.go
@@ -126,7 +126,7 @@ func CreateTestSqliteDB(t *testing.T) *TestSQLiteDB {
 		t.Fatalf("sqlite test: %v", err)
 	}
 
-	err = RunMigrations(logger, db, DatabaseConfig{SQLite: &SQLiteConfig{}})
+	err = RunMigrations(logger, DatabaseConfig{SQLite: &SQLiteConfig{}})
 	if err != nil {
 		t.Fatalf("sqlite test: %v", err)
 	}

--- a/database/sqlite.go
+++ b/database/sqlite.go
@@ -112,7 +112,7 @@ func (r *TestSQLiteDB) Close() error {
 //
 // Callers should call close on the returned *TestSQLiteDB.
 func CreateTestSqliteDB(t *testing.T) *TestSQLiteDB {
-	dir, err := ioutil.TempDir("", "paygate-sqlite")
+	dir, err := ioutil.TempDir("", "sqlite-test")
 	if err != nil {
 		t.Fatalf("sqlite test: %v", err)
 	}
@@ -122,7 +122,7 @@ func CreateTestSqliteDB(t *testing.T) *TestSQLiteDB {
 	// logger = log.NewNopLogger()
 	logger := log.NewDefaultLogger()
 
-	db, err := sqliteConnection(logger, filepath.Join(dir, "paygate.db")).Connect(ctx)
+	db, err := sqliteConnection(logger, filepath.Join(dir, "tests.db")).Connect(ctx)
 	if err != nil {
 		t.Fatalf("sqlite test: %v", err)
 	}

--- a/database/sqlite_test.go
+++ b/database/sqlite_test.go
@@ -36,12 +36,6 @@ func TestSQLite__basic(t *testing.T) {
 	conn.Close()
 }
 
-func TestSQLite__getSqlitePath(t *testing.T) {
-	if v := getSqlitePath(); v != "paygate.db" {
-		t.Errorf("got %s", v)
-	}
-}
-
 func TestSqliteUniqueViolation(t *testing.T) {
 	err := errors.New(`problem upserting depository="7d676c65eccd48090ff238a0d5e35eb6126c23f2", userId="80cfe1311d9eb7659d02cba9ee6cb04ed3739a85": UNIQUE constraint failed: depositories.depository_id`)
 	if !UniqueViolation(err) {

--- a/migrations/001_create_tests.up.sql
+++ b/migrations/001_create_tests.up.sql
@@ -1,0 +1,1 @@
+create table tests (id varchar(10))


### PR DESCRIPTION
This PR fixes 2 issues in base/database (which afaik is not used in other projects yet).

1. incorrect configuration of migration path
 
Expected behavior:
I can configure path to migrations files in `DatabaseConfig.migrationsDir` and they will be loaded from there during the migration

Actual behavior:
* There is no way to configure migrationsDir
* migrationsDir should be a module path (absolute path starting from the module root) and can't be treated as OS path. here is why:

Short: To embed migration files into binary we use [pkger](https://github.com/markbates/pkger/). `migrationsDir` can't be read by Pkger as Pkger uses static analysis and walks the AST of our application to find certain declarations such as pkger.Include and others. Because of this it can’t determine dynamic runtime values (which `migrationsDir` is).

Long (if you want to understand how pkger works): There are two modes of work in pkger.
**First,** if we tell pkger to read the file and it sees that this file was not embedded it tries to read it from disk. That's why when we run tests and pass migrations path as variable it works. Because /migration directory is there.
**Second,** if we build a binary (./bin/server) by providing migration file from configuration and we run our binary on the server where there is no directory /migrations it will try and fail to read it. In order to embed files into binary and be able to run it anywhere we should run `pkger` before we build our project. Like this (taken from [templater](https://github.com/moov-io/eng-project-templates/blob/master/.templates/go-service/Makefile#L84)):
```
$ pkger
$ go build -o ./bin/server cmd/server/*
```
`pkger` will walk the AST of our application and find all declarations with paths like `pkger.Include('/migrations')`. When it has all paths it will generate package.go file that will include the content of all scanned directories.

More about [how to use pkger](https://osinet.fr/go/en/articles/bundling-templates-with-pkger/).

2. no full clean up after dockertest

Expected behavior:
* when we run tests that launch MySQL instance in docker we expect all volumes to be removed after the test
* if test fails container should be stopped

Actual behavior:
* when test passes there is still volume with mysql instance container
* when test fails there is still running container

3. Use separate DB connection for service and migrations to avoid issue with not releasing 1 opened connection by migrator.

4. Unifies interface of `New` and `NewAndMigrate` functions