### PR TITLE
refactor logging package and add helpers

### DIFF
--- a/log/context.go
+++ b/log/context.go
@@ -1,5 +1,0 @@
-package log
-
-type Context interface {
-	Context() map[string]string
-}

--- a/log/logger.go
+++ b/log/logger.go
@@ -9,6 +9,13 @@ type Logger interface {
 	Error() Logger
 	Fatal() Logger
 
-	Logf(format string, a ...interface{})
-	LogErrorf(format string, a ...interface{}) error
+	Log(message string)
+	Logf(format string, args ...interface{})
+
+	LogError(error error) error
+	LogErrorf(format string, args ...interface{}) error
+}
+
+type Context interface {
+	Context() map[string]string
 }

--- a/log/logger_impl.go
+++ b/log/logger_impl.go
@@ -86,6 +86,10 @@ func (l *logger) Fatal() Logger {
 	return l.With(Fatal)
 }
 
+func (l *logger) Log(msg string) {
+	l.Logf(msg)
+}
+
 func (l *logger) Logf(format string, args ...interface{}) {
 	keyvals := make([]interface{}, (len(l.ctx)*2)+2)
 
@@ -100,6 +104,10 @@ func (l *logger) Logf(format string, args ...interface{}) {
 	}
 
 	_ = l.writer.Log(keyvals...)
+}
+
+func (l *logger) LogError(err error) error {
+	return l.LogErrorf(err.Error())
 }
 
 // LogError logs the error or creates a new one using the msg if `err` is nil and returns it.

--- a/log/logger_test.go
+++ b/log/logger_test.go
@@ -18,7 +18,7 @@ func Test_LogImplementations(t *testing.T) {
 func Test_Log(t *testing.T) {
 	a, buffer, log := Setup(t)
 
-	log.Logf("my message")
+	log.Log("my message")
 
 	a.Contains(buffer.String(), "my message")
 	a.Contains(buffer.String(), "level=info")
@@ -123,7 +123,7 @@ func Test_LogError(t *testing.T) {
 func Test_Caller(t *testing.T) {
 	a, buffer, log := Setup(t)
 
-	log.Info().With(StackTrace).Logf("message")
+	log.Info().With(stacktrace).Logf("message")
 	a.Regexp(regexp.MustCompile(`caller_0=(.*?)(\/log\/logger_test\.go)`), buffer.String())
 }
 

--- a/log/model_stacktrace.go
+++ b/log/model_stacktrace.go
@@ -8,8 +8,7 @@ import (
 
 type st string
 
-// Fatal sets level=fatal in the log output
-const StackTrace = st("stacktrace")
+const stacktrace = st("stacktrace")
 
 // Context returns the map that states that key value of `level={{l}}`
 func (s st) Context() map[string]string {


### PR DESCRIPTION
Added methods:
- `logger.Log(msg string)` which calls `logger.Logf(format string, args ...string)`
- `logger.LogError(err error) error` which calls `logger.LogErrorf(format string, args ...string)`

And moved interfaces and helper items to `logger.go` file to simplify package layout.