### PR TITLE
Set LogError() and LogErrorf() to return LoggedError struct instead of error

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"fmt"
 	"os"
 	"strings"
 
@@ -28,18 +27,18 @@ func (s *Service) Load(config interface{}) error {
 	}
 
 	if file, ok := os.LookupEnv("APP_CONFIG"); ok && strings.TrimSpace(file) != "" {
-		log := s.logger.Set("app_config", file)
-		log.Info().Logf("Loading APP_CONFIG config file")
+		logger := s.logger.Set("app_config", file)
+		logger.Info().Logf("Loading APP_CONFIG config file")
 
 		overrides := viper.New()
 		overrides.SetConfigFile(file)
 
 		if err := overrides.ReadInConfig(); err != nil {
-			return log.LogErrorf(fmt.Sprintf("Failed loading the specific app config - %s", err), err)
+			return logger.LogErrorf("Failed loading the specific app config: %w", err).Err()
 		}
 
 		if err := overrides.Unmarshal(config); err != nil {
-			return log.LogErrorf(fmt.Sprintf("Unable to unmarshal the specific app config - %s", err), err)
+			return logger.LogErrorf("Unable to unmarshal the specific app config: %w", err).Err()
 		}
 	}
 
@@ -47,22 +46,22 @@ func (s *Service) Load(config interface{}) error {
 }
 
 func (s *Service) LoadFile(file string, config interface{}) error {
-	log := s.logger.Set("file", file)
-	log.Info().Logf("loading config file")
+	logger := s.logger.Set("file", file)
+	logger.Info().Logf("loading config file")
 
 	f, err := pkger.Open(file)
 	if err != nil {
-		return log.LogErrorf("pkger unable to load", err)
+		return logger.LogErrorf("pkger unable to load: %w", err).Err()
 	}
 
 	deflt := viper.New()
 	deflt.SetConfigType("yaml")
 	if err := deflt.ReadConfig(f); err != nil {
-		return log.LogErrorf("unable to load the defaults", err)
+		return logger.LogErrorf("unable to load the defaults: %w", err).Err()
 	}
 
 	if err := deflt.Unmarshal(config); err != nil {
-		return log.LogErrorf("unable to unmarshal the defaults", err)
+		return logger.LogErrorf("unable to unmarshal the defaults: %w", err).Err()
 	}
 
 	return nil

--- a/database/migrator.go
+++ b/database/migrator.go
@@ -15,12 +15,12 @@ import (
 	"github.com/moov-io/base/log"
 )
 
-func RunMigrations(log log.Logger, db *sql.DB, config DatabaseConfig) error {
+func RunMigrations(logger log.Logger, db *sql.DB, config DatabaseConfig) error {
 	if _, err := os.Stat(config.migrationsDir); os.IsNotExist(err) {
 		return fmt.Errorf("migrations directory=\"%s\" does not exist", config.migrationsDir)
 	}
 
-	log.Info().Logf("Running Migrations")
+	logger.Info().Logf("Running Migrations")
 	_ = pkger.Include(config.migrationsDir)
 
 	driver, err := GetDriver(db, config)
@@ -34,19 +34,19 @@ func RunMigrations(log log.Logger, db *sql.DB, config DatabaseConfig) error {
 		driver,
 	)
 	if err != nil {
-		return log.Fatal().LogErrorf("Error running migration - %w", err)
+		return logger.Fatal().LogErrorf("Error running migration: %w", err).Err()
 	}
 
 	err = m.Up()
 	switch err {
 	case nil:
 	case migrate.ErrNoChange:
-		log.Info().Logf("Database already at version")
+		logger.Info().Logf("Database already at version")
 	default:
-		return log.Fatal().LogErrorf("Error running migrations - %w", err)
+		return logger.Fatal().LogErrorf("Error running migrations: %w", err).Err()
 	}
 
-	log.Info().Logf("Migrations complete")
+	logger.Info().Logf("Migrations complete")
 
 	return nil
 }

--- a/log/logger.go
+++ b/log/logger.go
@@ -12,8 +12,8 @@ type Logger interface {
 	Log(message string)
 	Logf(format string, args ...interface{})
 
-	LogError(error error)
-	LogErrorf(format string, args ...interface{}) error
+	LogError(error error) LoggedError
+	LogErrorf(format string, args ...interface{}) LoggedError
 }
 
 type Context interface {

--- a/log/logger.go
+++ b/log/logger.go
@@ -12,7 +12,7 @@ type Logger interface {
 	Log(message string)
 	Logf(format string, args ...interface{})
 
-	LogError(error error) error
+	LogError(error error)
 	LogErrorf(format string, args ...interface{}) error
 }
 

--- a/log/logger_impl.go
+++ b/log/logger_impl.go
@@ -37,6 +37,8 @@ func NewLogger(writer log.Logger) Logger {
 	return l.Info()
 }
 
+var _ Logger = (*logger)(nil)
+
 type logger struct {
 	writer log.Logger
 	ctx    map[string]string
@@ -106,8 +108,8 @@ func (l *logger) Logf(format string, args ...interface{}) {
 	_ = l.writer.Log(keyvals...)
 }
 
-func (l *logger) LogError(err error) error {
-	return l.LogErrorf(err.Error())
+func (l *logger) LogError(err error) {
+	_ = l.LogErrorf(err.Error())
 }
 
 // LogError logs the error or creates a new one using the msg if `err` is nil and returns it.

--- a/log/logger_impl.go
+++ b/log/logger_impl.go
@@ -109,13 +109,21 @@ func (l *logger) Logf(format string, args ...interface{}) {
 	l.Log(msg)
 }
 
-func (l *logger) LogError(err error) {
+func (l *logger) LogError(err error) LoggedError {
 	l.Set("errored", "true").Log(err.Error())
+	return LoggedError{err}
 }
 
 // LogError logs the error or creates a new one using the msg if `err` is nil and returns it.
-func (l *logger) LogErrorf(format string, args ...interface{}) error {
+func (l *logger) LogErrorf(format string, args ...interface{}) LoggedError {
 	err := fmt.Errorf(format, args...)
-	l.LogError(err)
-	return err
+	return l.LogError(err)
+}
+
+type LoggedError struct {
+	err error
+}
+
+func (l LoggedError) Err() error {
+	return l.err
 }

--- a/log/logger_impl.go
+++ b/log/logger_impl.go
@@ -89,14 +89,10 @@ func (l *logger) Fatal() Logger {
 }
 
 func (l *logger) Log(msg string) {
-	l.Logf(msg)
-}
-
-func (l *logger) Logf(format string, args ...interface{}) {
 	keyvals := make([]interface{}, (len(l.ctx)*2)+2)
 
 	keyvals[0] = "msg"
-	keyvals[1] = fmt.Sprintf(format, args...)
+	keyvals[1] = msg
 
 	i := 2
 	for k, v := range l.ctx {
@@ -108,13 +104,18 @@ func (l *logger) Logf(format string, args ...interface{}) {
 	_ = l.writer.Log(keyvals...)
 }
 
+func (l *logger) Logf(format string, args ...interface{}) {
+	msg := fmt.Sprintf(format, args...)
+	l.Log(msg)
+}
+
 func (l *logger) LogError(err error) {
-	_ = l.LogErrorf(err.Error())
+	l.Set("errored", "true").Log(err.Error())
 }
 
 // LogError logs the error or creates a new one using the msg if `err` is nil and returns it.
 func (l *logger) LogErrorf(format string, args ...interface{}) error {
-	newErr := fmt.Errorf(format, args...)
-	l.Set("errored", "true").Logf(newErr.Error())
-	return newErr
+	err := fmt.Errorf(format, args...)
+	l.LogError(err)
+	return err
 }

--- a/log/logger_test.go
+++ b/log/logger_test.go
@@ -2,6 +2,7 @@ package log
 
 import (
 	"errors"
+	"fmt"
 	"regexp"
 	"strings"
 	"testing"
@@ -118,6 +119,10 @@ func Test_LogError(t *testing.T) {
 	output := buffer.String()
 	a.Contains(output, "errored=true")
 	a.Contains(output, "msg=\"wrap: othererror\"")
+
+	wrappedErr := fmt.Errorf("wrapped: %w", newErr)
+	gotErr := log.LogError(wrappedErr).Err()
+	a.True(errors.Is(gotErr, newErr))
 }
 
 func Test_Caller(t *testing.T) {

--- a/log/logger_test.go
+++ b/log/logger_test.go
@@ -112,12 +112,12 @@ func Test_LogError(t *testing.T) {
 	a, buffer, log := Setup(t)
 
 	newErr := errors.New("othererror")
-	err := log.LogErrorf("%w", newErr)
-	a.Equal("othererror", err.Error())
+	err := log.LogErrorf("wrap: %w", newErr).Err()
+	a.Equal("wrap: othererror", err.Error())
 
 	output := buffer.String()
 	a.Contains(output, "errored=true")
-	a.Contains(output, "msg=othererror")
+	a.Contains(output, "msg=\"wrap: othererror\"")
 }
 
 func Test_Caller(t *testing.T) {


### PR DESCRIPTION
In our previous implementation:
```go
// causes linter warning 
logger.LogError(err)
// Using a blank identifier is awkward and may set off linter warnings because it's still ignoring the error
_ = logger.LogError(err)
```

So having `logger.LogError()` return a custom struct, `LoggedError`, that holds the error allows us to do
```go
logger.LogError(err) // no linter warning!

or

if err != nil {
  return logger.LogError(err).Err() // inlined
}
```