### PR TITLE
Fix test sqlite db helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v0.13.1
+
+FIXES:
+
+- database: CreateTestSqliteDB didn't use path of SQLite DB for migrations
+
 ## v0.13.0 (Released 2020-10-16)
 
 **BREAKING CHANGES**


### PR DESCRIPTION
With the latest changes when we use two separate DB connections for the service and for migrations a bug was introduced. SQLite helper (CreateTestSqliteDB) didn't use proper path of SQLite DB file for migrations. This PR fixes this bug.
