### PR TITLE
Add timestamp field to all logs

### DIFF
--- a/log/logger_impl.go
+++ b/log/logger_impl.go
@@ -92,7 +92,7 @@ func (l *logger) Fatal() Logger {
 func (l *logger) Log(msg string) {
 	orig := []string{
 		"msg", msg,
-		"time", time.Now().UTC().Format(time.RFC3339),
+		"ts", time.Now().UTC().Format(time.RFC3339),
 	}
 
 	keyvals := make([]interface{}, (len(l.ctx)*2)+len(orig))

--- a/log/logger_impl.go
+++ b/log/logger_impl.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/go-kit/kit/log"
 )
@@ -89,12 +90,17 @@ func (l *logger) Fatal() Logger {
 }
 
 func (l *logger) Log(msg string) {
-	keyvals := make([]interface{}, (len(l.ctx)*2)+2)
+	orig := []string{
+		"msg", msg,
+		"time", time.Now().UTC().Format(time.RFC3339),
+	}
 
-	keyvals[0] = "msg"
-	keyvals[1] = msg
+	keyvals := make([]interface{}, (len(l.ctx)*2)+len(orig))
+	for i, v := range orig {
+		keyvals[i] = v
+	}
 
-	i := 2
+	i := len(orig)
 	for k, v := range l.ctx {
 		keyvals[i] = k
 		keyvals[i+1] = v

--- a/log/logger_test.go
+++ b/log/logger_test.go
@@ -6,6 +6,7 @@ import (
 	"regexp"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -20,9 +21,19 @@ func Test_Log(t *testing.T) {
 	a, buffer, log := Setup(t)
 
 	log.Log("my message")
+	got := buffer.String()
 
-	a.Contains(buffer.String(), "my message")
-	a.Contains(buffer.String(), "level=info")
+	a.Contains(got, "my message")
+	a.Contains(got, "level=info")
+
+	// check valid timestamp
+	idx := strings.Index(got, "time=")
+	a.NotEqual(idx, -1)
+	timestamp := got[idx+len("time="):]
+	timestamp = strings.Split(timestamp, " ")[0]
+	ts, err := time.Parse(time.RFC3339, timestamp)
+	a.NoError(err)
+	a.NotZero(ts)
 }
 
 func Test_WithContext(t *testing.T) {

--- a/log/logger_test.go
+++ b/log/logger_test.go
@@ -27,9 +27,10 @@ func Test_Log(t *testing.T) {
 	a.Contains(got, "level=info")
 
 	// check valid timestamp
-	idx := strings.Index(got, "time=")
+	tsKey := "ts="
+	idx := strings.Index(got, tsKey)
 	a.NotEqual(idx, -1)
-	timestamp := got[idx+len("time="):]
+	timestamp := got[idx+len(tsKey):]
 	timestamp = strings.Split(timestamp, " ")[0]
 	ts, err := time.Parse(time.RFC3339, timestamp)
 	a.NoError(err)


### PR DESCRIPTION
All logs would have a key-value pair like `time=2020-10-20T05:09:49Z` in `UTC`

Fixes #109 