### PR TITLE
sqlite: reuse the db connection after running migrations

### DIFF
--- a/database/database.go
+++ b/database/database.go
@@ -26,18 +26,13 @@ func NewAndMigrate(ctx context.Context, logger log.Logger, config DatabaseConfig
 	}
 
 	// run migrations first
-	db, err := RunMigrations(logger, config)
+	err := RunMigrations(logger, config)
 	if err != nil {
 		return nil, err
 	}
 
-	// In SQLite, we can reuse the same connection
-	if config.SQLite != nil {
-		return db, nil
-	}
-
 	// create DB connection for our service
-	db, err = New(ctx, logger, config)
+	db, err := New(ctx, logger, config)
 	if err != nil {
 		return nil, err
 	}

--- a/database/database.go
+++ b/database/database.go
@@ -31,12 +31,17 @@ func NewAndMigrate(ctx context.Context, logger log.Logger, config DatabaseConfig
 		return nil, err
 	}
 
-	// // create DB connection for our service
-	// db, err := New(ctx, logger, config)
-	// if err != nil {
-	// 	return nil, err
-	// }
-	//
+	// In SQLite, we can reuse the same connection
+	if config.SQLite != nil {
+		return db, nil
+	}
+
+	// create DB connection for our service
+	db, err = New(ctx, logger, config)
+	if err != nil {
+		return nil, err
+	}
+
 	return db, nil
 }
 

--- a/database/database.go
+++ b/database/database.go
@@ -25,21 +25,18 @@ func NewAndMigrate(ctx context.Context, logger log.Logger, config DatabaseConfig
 		logger = log.NewNopLogger()
 	}
 
-	if ctx == nil {
-		ctx = context.Background()
-	}
-
 	// run migrations first
-	if err := RunMigrations(logger, config); err != nil {
-		return nil, err
-	}
-
-	// create DB connection for our service
-	db, err := New(ctx, logger, config)
+	db, err := RunMigrations(logger, config)
 	if err != nil {
 		return nil, err
 	}
 
+	// // create DB connection for our service
+	// db, err := New(ctx, logger, config)
+	// if err != nil {
+	// 	return nil, err
+	// }
+	//
 	return db, nil
 }
 

--- a/database/database_test.go
+++ b/database/database_test.go
@@ -13,6 +13,7 @@ func Test_NewAndMigration_SQLite3(t *testing.T) {
 	if err != nil {
 		t.FailNow()
 	}
+
 	db.Close()
 }
 

--- a/database/migrator.go
+++ b/database/migrator.go
@@ -15,10 +15,10 @@ import (
 	"github.com/moov-io/base/log"
 )
 
-func RunMigrations(logger log.Logger, config DatabaseConfig) (*sql.DB, error) {
+func RunMigrations(logger log.Logger, config DatabaseConfig) error {
 	db, err := New(context.Background(), logger, config)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	logger.Info().Log("Running Migrations")
@@ -27,7 +27,7 @@ func RunMigrations(logger log.Logger, config DatabaseConfig) (*sql.DB, error) {
 
 	driver, err := GetDriver(db, config)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	m, err := migrate.NewWithDatabaseInstance(
@@ -36,7 +36,7 @@ func RunMigrations(logger log.Logger, config DatabaseConfig) (*sql.DB, error) {
 		driver,
 	)
 	if err != nil {
-		return nil, logger.Fatal().LogErrorf("Error running migration: %w", err).Err()
+		return logger.Fatal().LogErrorf("Error running migration: %w", err).Err()
 	}
 
 	err = m.Up()
@@ -45,12 +45,11 @@ func RunMigrations(logger log.Logger, config DatabaseConfig) (*sql.DB, error) {
 	case migrate.ErrNoChange:
 		logger.Info().Log("Database already at version")
 	default:
-		return nil, logger.Fatal().LogErrorf("Error running migrations: %w", err).Err()
+		return logger.Fatal().LogErrorf("Error running migrations: %w", err).Err()
 	}
 
 	logger.Info().Log("Migrations complete")
-
-	return db, nil
+	return nil
 }
 
 func GetDriver(db *sql.DB, config DatabaseConfig) (database.Driver, error) {

--- a/database/model_config.go
+++ b/database/model_config.go
@@ -19,6 +19,6 @@ type SQLiteConfig struct {
 var InMemorySqliteConfig = DatabaseConfig{
 	DatabaseName: "sqlite",
 	SQLite: &SQLiteConfig{
-		Path: ":memory:",
+		Path: "file::memory:?cache=shared",
 	},
 }

--- a/database/mysql_test.go
+++ b/database/mysql_test.go
@@ -5,8 +5,9 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/moov-io/base/log"
 	"github.com/stretchr/testify/require"
+
+	"github.com/moov-io/base/log"
 )
 
 func TestMySQL__basic(t *testing.T) {

--- a/database/sqlite_test.go
+++ b/database/sqlite_test.go
@@ -6,6 +6,8 @@ import (
 	"runtime"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/moov-io/base/log"
 )
 
@@ -34,6 +36,14 @@ func TestSQLite__basic(t *testing.T) {
 	cancelFunc()
 
 	conn.Close()
+}
+
+func TestSQLite_InMemoryConfig(t *testing.T) {
+	db, err := NewAndMigrate(context.Background(), log.NewNopLogger(), InMemorySqliteConfig)
+	require.NoError(t, err)
+
+	_, err = db.Query("select * from tests")
+	require.NoError(t, err)
 }
 
 func TestSqliteUniqueViolation(t *testing.T) {


### PR DESCRIPTION
Ensure that `InMemorySQLiteConfig` can be shared.