### PR TITLE
remove global var InMemorySQLite and minor refactor

### DIFF
--- a/database/database.go
+++ b/database/database.go
@@ -46,5 +46,5 @@ func NewAndMigrate(ctx context.Context, logger log.Logger, config DatabaseConfig
 // UniqueViolation returns true when the provided error matches a database error
 // for duplicate entries (violating a unique table constraint).
 func UniqueViolation(err error) bool {
-	return MySQLUniqueViolation(err) || SqliteUniqueViolation(err)
+	return MySQLUniqueViolation(err) || SQLiteUniqueViolation(err)
 }

--- a/database/database_test.go
+++ b/database/database_test.go
@@ -23,6 +23,7 @@ func Test_NewAndMigration_SQLite(t *testing.T) {
 	}}
 
 	db, err := NewAndMigrate(context.Background(), nil, *config)
+	require.NoError(t, err)
 	defer db.Close()
 
 	require.NoError(t, err)

--- a/database/database_test.go
+++ b/database/database_test.go
@@ -3,17 +3,29 @@ package database
 import (
 	"context"
 	"errors"
+	"io/ioutil"
+	"os"
+	"path/filepath"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 
 	"github.com/moov-io/base/docker"
 )
 
-func Test_NewAndMigration_SQLite3(t *testing.T) {
-	db, err := NewAndMigrate(context.Background(), nil, InMemorySqliteConfig)
-	if err != nil {
-		t.FailNow()
-	}
-	db.Close()
+func Test_NewAndMigration_SQLite(t *testing.T) {
+	dir, err := ioutil.TempDir("", "sqlite-test")
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
+
+	config := &DatabaseConfig{SQLite: &SQLiteConfig{
+		Path: filepath.Join(dir, "tests.db"),
+	}}
+
+	db, err := NewAndMigrate(context.Background(), nil, *config)
+	require.NoError(t, err)
+	_, err = db.Query("select * from tests")
+	require.NoError(t, err)
 }
 
 func Test_NewAndMigration_MySql(t *testing.T) {

--- a/database/database_test.go
+++ b/database/database_test.go
@@ -23,6 +23,8 @@ func Test_NewAndMigration_SQLite(t *testing.T) {
 	}}
 
 	db, err := NewAndMigrate(context.Background(), nil, *config)
+	defer db.Close()
+
 	require.NoError(t, err)
 	_, err = db.Query("select * from tests")
 	require.NoError(t, err)

--- a/database/error.go
+++ b/database/error.go
@@ -1,0 +1,14 @@
+package database
+
+import "fmt"
+
+// ErrOpenConnections describes the number of open connections that should have been closed by a call to Close().
+// All queries/transactions should call Close() to prevent unused, open connections.
+type ErrOpenConnections struct {
+	Database       string
+	NumConnections int
+}
+
+func (e ErrOpenConnections) Error() string {
+	return fmt.Sprintf("found %d open connection(s) in %s", e.NumConnections, e.Database)
+}

--- a/database/model_config.go
+++ b/database/model_config.go
@@ -15,10 +15,3 @@ type MySQLConfig struct {
 type SQLiteConfig struct {
 	Path string
 }
-
-var InMemorySqliteConfig = DatabaseConfig{
-	DatabaseName: "sqlite",
-	SQLite: &SQLiteConfig{
-		Path: ":memory:",
-	},
-}

--- a/database/sqlite.go
+++ b/database/sqlite.go
@@ -96,8 +96,8 @@ func (r *TestSQLiteDB) Close() error {
 	r.shutdown()
 
 	// Verify all connections are closed before closing DB
-	if conns := r.DB.Stats().Idle; conns != 0 {
-		panic(fmt.Sprintf("found %d open sqlite connection(s)", conns))
+	if conns := r.DB.Stats().OpenConnections; conns != 0 {
+		panic(fmt.Sprintf("found %d open sqlite connections", conns))
 	}
 	if err := r.DB.Close(); err != nil {
 		return err

--- a/database/sqlite_test.go
+++ b/database/sqlite_test.go
@@ -19,8 +19,8 @@ func TestSQLite__basic(t *testing.T) {
 	require.NoError(t, err)
 
 	r, err := db.Query("select * from tests")
-	defer r.Close()
 	require.NoError(t, err)
+	defer r.Close()
 
 	if runtime.GOOS == "windows" {
 		t.Skip("/dev/null doesn't exist on Windows")

--- a/database/sqlite_test.go
+++ b/database/sqlite_test.go
@@ -18,7 +18,8 @@ func TestSQLite__basic(t *testing.T) {
 	err := db.DB.Ping()
 	require.NoError(t, err)
 
-	_, err = db.Query("select * from tests")
+	r, err := db.Query("select * from tests")
+	defer r.Close()
 	require.NoError(t, err)
 
 	if runtime.GOOS == "windows" {

--- a/database/sqlite_test.go
+++ b/database/sqlite_test.go
@@ -6,16 +6,20 @@ import (
 	"runtime"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/moov-io/base/log"
 )
 
 func TestSQLite__basic(t *testing.T) {
-	db := CreateTestSqliteDB(t)
+	db := CreateTestSQLiteDB(t)
 	defer db.Close()
 
-	if err := db.DB.Ping(); err != nil {
-		t.Fatal(err)
-	}
+	err := db.DB.Ping()
+	require.NoError(t, err)
+
+	_, err = db.Query("select * from tests")
+	require.NoError(t, err)
 
 	if runtime.GOOS == "windows" {
 		t.Skip("/dev/null doesn't exist on Windows")
@@ -27,16 +31,15 @@ func TestSQLite__basic(t *testing.T) {
 	ctx, cancelFunc := context.WithCancel(context.Background())
 
 	conn, _ := s.Connect(ctx)
-	if err := conn.Ping(); err == nil {
-		t.Error("expected error")
-	}
+	err = conn.Ping()
+	require.EqualError(t, err, "unable to open database file")
 
 	cancelFunc()
 
 	conn.Close()
 }
 
-func TestSqliteUniqueViolation(t *testing.T) {
+func TestSQLiteUniqueViolation(t *testing.T) {
 	err := errors.New(`problem upserting depository="7d676c65eccd48090ff238a0d5e35eb6126c23f2", userId="80cfe1311d9eb7659d02cba9ee6cb04ed3739a85": UNIQUE constraint failed: depositories.depository_id`)
 	if !UniqueViolation(err) {
 		t.Error("should have matched unique violation")


### PR DESCRIPTION
- Removed global var `InMemorySqliteConfig` to avoid incorrect usage in tests; all services should call `CreateTestSQLiteDB()` for testing with sqlite
- Renamed instances of `Sqlite` to `SQLite`
- Improved tests to check proper behavior