### PR TITLE
database: optimize testing by sharing one mysql container

### DIFF
--- a/.github/workflows/mysql-volumeless.yml
+++ b/.github/workflows/mysql-volumeless.yml
@@ -1,0 +1,26 @@
+name: Publish MySQL Docker Image
+
+on:
+  push:
+    tags: [ "v*.*.*" ]
+
+jobs:
+  docker:
+    name: Build and push MySQL volumeless docker image
+    runs-on: ubuntu-latest
+    defaults:
+      working-directory: ./mysql
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v2
+
+    - name: Build docker image from MySQL initialized DB inside container
+      run: make build
+
+    - name: Docker Push
+      run: |+
+          echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+          make push
+      env:
+        DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+        DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/mysql-volumeless.yml
+++ b/.github/workflows/mysql-volumeless.yml
@@ -9,7 +9,8 @@ jobs:
     name: Build and push MySQL volumeless docker image
     runs-on: ubuntu-latest
     defaults:
-      working-directory: ./mysql
+      run:
+        working-directory: ./mysql
     steps:
     - name: Check out code
       uses: actions/checkout@v2

--- a/database/database_test.go
+++ b/database/database_test.go
@@ -36,13 +36,18 @@ func Test_NewAndMigration_MySql(t *testing.T) {
 		t.SkipNow()
 	}
 
-	config, err := findOrLaunchMySQLContainer()
+	mySQLConfig, err := findOrLaunchMySQLContainer()
 	require.NoError(t, err)
 
-	config.DatabaseName, err = CreateTemporaryDatabase(config)
+	databaseName, err := CreateTemporaryDatabase(mySQLConfig)
 	require.NoError(t, err)
 
-	db, err := NewAndMigrate(context.Background(), nil, *config)
+	config := DatabaseConfig{
+		DatabaseName: databaseName,
+		MySQL:        mySQLConfig,
+	}
+
+	db, err := NewAndMigrate(context.Background(), nil, config)
 	require.NoError(t, err)
 	db.Close()
 }

--- a/database/database_test.go
+++ b/database/database_test.go
@@ -42,10 +42,11 @@ func Test_NewAndMigration_MySql(t *testing.T) {
 	}
 	defer container.Close()
 
+	config.DatabaseName, err = CreateTemporaryDatabase(config)
+	require.NoError(t, err)
+
 	db, err := NewAndMigrate(context.Background(), nil, *config)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	db.Close()
 }
 

--- a/database/database_test.go
+++ b/database/database_test.go
@@ -39,7 +39,7 @@ func Test_NewAndMigration_MySql(t *testing.T) {
 	mySQLConfig, err := findOrLaunchMySQLContainer()
 	require.NoError(t, err)
 
-	databaseName, err := CreateTemporaryDatabase(mySQLConfig)
+	databaseName, err := createTemporaryDatabase(mySQLConfig)
 	require.NoError(t, err)
 
 	config := DatabaseConfig{

--- a/database/database_test.go
+++ b/database/database_test.go
@@ -36,11 +36,8 @@ func Test_NewAndMigration_MySql(t *testing.T) {
 		t.SkipNow()
 	}
 
-	config, container, err := RunMySQLDockerInstance(&DatabaseConfig{})
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer container.Close()
+	config, err := findOrLaunchMySQLContainer()
+	require.NoError(t, err)
 
 	config.DatabaseName, err = CreateTemporaryDatabase(config)
 	require.NoError(t, err)

--- a/database/mysql.go
+++ b/database/mysql.go
@@ -211,7 +211,7 @@ func createTemporaryDatabase(config *MySQLConfig) (string, error) {
 }
 
 func findOrLaunchMySQLContainer() (*MySQLConfig, error) {
-	var containerName = "mysql-test-container"
+	var containerName = "moov-mysql-test-container"
 	var resource *dockertest.Resource
 	var err error
 

--- a/database/mysql.go
+++ b/database/mysql.go
@@ -227,7 +227,7 @@ func findOrLaunchMySQLContainer() (*MySQLConfig, error) {
 
 	_, err = pool.RunWithOptions(&dockertest.RunOptions{
 		Name:       containerName,
-		Repository: "vaulty/mysql-volumeless",
+		Repository: "moov/mysql-volumeless",
 		Tag:        "8.0",
 		Env: []string{
 			fmt.Sprintf("MYSQL_USER=%s", config.User),

--- a/database/mysql.go
+++ b/database/mysql.go
@@ -197,13 +197,12 @@ func RunMySQLDockerInstance(config *DatabaseConfig) (*DatabaseConfig, *dockertes
 	}
 
 	resource, err := pool.RunWithOptions(&dockertest.RunOptions{
-		Repository: "mysql",
-		Tag:        "8",
+		Repository: "vaulty/mysql-volumeless",
+		Tag:        "8.0",
 		Env: []string{
 			fmt.Sprintf("MYSQL_USER=%s", config.MySQL.User),
 			fmt.Sprintf("MYSQL_PASSWORD=%s", config.MySQL.Password),
-			"MYSQL_ROOT_PASSWORD=secret",
-			fmt.Sprintf("MYSQL_DATABASE=%s", config.DatabaseName),
+			fmt.Sprintf("MYSQL_ROOT_PASSWORD=%s", config.MySQL.Password),
 		},
 	}, func(dockerConfig *dc.HostConfig) {
 		dockerConfig.AutoRemove = true

--- a/database/mysql.go
+++ b/database/mysql.go
@@ -159,7 +159,7 @@ func CreateTestMySQLDB(t *testing.T) *TestMySQLDB {
 		require.NoError(t, err)
 	})
 
-	dbName, err := CreateTemporaryDatabase(sharedMySQLConfig)
+	dbName, err := createTemporaryDatabase(sharedMySQLConfig)
 	require.NoError(t, err)
 
 	dbConfig := &DatabaseConfig{
@@ -187,7 +187,7 @@ func CreateTestMySQLDB(t *testing.T) *TestMySQLDB {
 
 // We connect as root to MySQL server and create database with random name to
 // run our migrations on it later.
-func CreateTemporaryDatabase(config *MySQLConfig) (string, error) {
+func createTemporaryDatabase(config *MySQLConfig) (string, error) {
 	dsn := fmt.Sprintf("%s:%s@%s/", "root", config.Password, config.Address)
 	db, err := sql.Open("mysql", dsn)
 	if err != nil {

--- a/database/mysql_test.go
+++ b/database/mysql_test.go
@@ -41,3 +41,13 @@ func TestMySQLUniqueViolation(t *testing.T) {
 		t.Error("should have matched unique violation")
 	}
 }
+
+func TestCreateTemporaryDatabase(t *testing.T) {
+	config, container, err := RunMySQLDockerInstance(&DatabaseConfig{})
+	require.NoError(t, err)
+	defer container.Close()
+
+	name, err := CreateTemporaryDatabase(config)
+	require.NoError(t, err)
+	require.Contains(t, name, "test")
+}

--- a/database/mysql_test.go
+++ b/database/mysql_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/moov-io/base/docker"
 	"github.com/moov-io/base/log"
 	"github.com/stretchr/testify/require"
 )
@@ -43,9 +44,12 @@ func TestMySQLUniqueViolation(t *testing.T) {
 }
 
 func TestCreateTemporaryDatabase(t *testing.T) {
-	config, container, err := RunMySQLDockerInstance(&DatabaseConfig{})
+	if !docker.Enabled() {
+		t.Skip("Docker not enabled")
+	}
+
+	config, _, err := RunMySQLDockerInstance(&DatabaseConfig{})
 	require.NoError(t, err)
-	defer container.Close()
 
 	name, err := CreateTemporaryDatabase(config)
 	require.NoError(t, err)

--- a/database/mysql_test.go
+++ b/database/mysql_test.go
@@ -51,7 +51,7 @@ func TestCreateTemporaryDatabase(t *testing.T) {
 	config, err := findOrLaunchMySQLContainer()
 	require.NoError(t, err)
 
-	name, err := CreateTemporaryDatabase(config)
+	name, err := createTemporaryDatabase(config)
 	require.NoError(t, err)
 	require.Contains(t, name, "test")
 }

--- a/database/mysql_test.go
+++ b/database/mysql_test.go
@@ -48,7 +48,7 @@ func TestCreateTemporaryDatabase(t *testing.T) {
 		t.Skip("Docker not enabled")
 	}
 
-	config, _, err := RunMySQLDockerInstance(&DatabaseConfig{})
+	config, err := findOrLaunchMySQLContainer()
 	require.NoError(t, err)
 
 	name, err := CreateTemporaryDatabase(config)

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/go-kit/kit v0.10.0
 	github.com/go-sql-driver/mysql v1.5.0
 	github.com/golang-migrate/migrate/v4 v4.13.0
+	github.com/google/uuid v1.1.1
 	github.com/gorilla/mux v1.8.0
 	github.com/hashicorp/golang-lru v0.5.4
 	github.com/markbates/pkger v0.17.1

--- a/go.sum
+++ b/go.sum
@@ -238,6 +238,7 @@ github.com/google/pprof v0.0.0-20200430221834-fc25d7d30c6d/go.mod h1:ZgVRPoUq/hf
 github.com/google/pprof v0.0.0-20200708004538-1a94d8640e99/go.mod h1:ZgVRPoUq/hfqzAqh7sHMqb3I9Rq5C59dIz2SbBwJ4eM=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/google/uuid v1.1.1 h1:Gkbcsh/GbpXz7lPftLA3P6TYMwjCLYm83jiFQZF/3gY=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=

--- a/mysql/Dockerfile
+++ b/mysql/Dockerfile
@@ -1,0 +1,4 @@
+FROM mysql:8.0
+
+RUN mkdir /var/lib/mysql-volume
+CMD ["--datadir", "/var/lib/mysql-volume"]

--- a/mysql/README.md
+++ b/mysql/README.md
@@ -1,0 +1,42 @@
+# MySQL docker image for testing
+
+In order to speedup testing with MySQL we created custom docker image for MySQL that stores
+data inside container (not outside in volume).
+
+# Update Image
+
+In order to update image please follow this steps:
+
+Updated `Dockerfile` if needed and then build the image:
+
+```
+make build
+```
+
+Run the container from this image to initialize database and create all necessary files inside container
+
+```
+make run
+```
+
+After container is ready (you will see that it's "...ready for connections..."), please, stop the container with
+
+```
+make stop
+```
+
+at this point we have a container with initialized MySQL database
+
+Now it's time to make image based on this container:
+
+```
+make image
+```
+
+Final step is to push image to docker hub:
+
+```
+make push
+```
+
+That's it!

--- a/mysql/makefile
+++ b/mysql/makefile
@@ -1,19 +1,18 @@
-build:
+build: clean
 	docker build -t mysql-volumeless:8.0 .
-
-run:
-	docker run --name mysql-volumeless \
+	docker run -d \
+	       	--name mysql-volumeless \
 		-e MYSQL_USER=moov \
 		-e MYSQL_PASSWORD=secret \
 		-e MYSQL_ROOT_PASSWORD=secret \
+		-e MYSQL_DATABASE=test \
+		-p 3306:3306 \
 	       	mysql-volumeless:8.0
-
-stop:
+	./test-mysql-is-ready.sh
 	docker stop mysql-volumeless
-
-image:
 	docker commit mysql-volumeless mysql-volumeless:8.0
-	docker tag mysql-volumeless:8.0 vaulty/mysql-volumeless:8.0
-
+	docker tag mysql-volumeless:8.0 moov/mysql-volumeless:8.0
 push:
-	docker push vaulty/mysql-volumeless:8.0
+	docker push moov/mysql-volumeless:8.0
+clean:
+	docker rm mysql-volumeless

--- a/mysql/makefile
+++ b/mysql/makefile
@@ -1,3 +1,5 @@
+DOCKER_CONTAINER_LIST := $(shell docker ps -aq -f status=exited -f name=mysql-volumeless)
+
 build: clean
 	docker build -t mysql-volumeless:8.0 .
 	docker run -d \
@@ -15,4 +17,4 @@ build: clean
 push:
 	docker push moov/mysql-volumeless:8.0
 clean:
-	docker rm mysql-volumeless
+	@if [ -n "$(DOCKER_CONTAINER_LIST)" ]; then docker rm "$(DOCKER_CONTAINER_LIST)"; fi;

--- a/mysql/makefile
+++ b/mysql/makefile
@@ -1,0 +1,19 @@
+build:
+	docker build -t mysql-volumeless:8.0 .
+
+run:
+	docker run --name mysql-volumeless \
+		-e MYSQL_USER=moov \
+		-e MYSQL_PASSWORD=secret \
+		-e MYSQL_ROOT_PASSWORD=secret \
+	       	mysql-volumeless:8.0
+
+stop:
+	docker stop mysql-volumeless
+
+image:
+	docker commit mysql-volumeless mysql-volumeless:8.0
+	docker tag mysql-volumeless:8.0 vaulty/mysql-volumeless:8.0
+
+push:
+	docker push vaulty/mysql-volumeless:8.0

--- a/mysql/test-mysql-is-ready.sh
+++ b/mysql/test-mysql-is-ready.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -e
+
+ATTEMPTS=0
+
+until docker exec mysql-volumeless mysql -h localhost -u moov -psecret --protocol=TCP -e "SELECT VERSION();SELECT NOW()" test || [ $ATTEMPTS -ge 10 ]
+do
+	((ATTEMPTS+=1))
+	echo "Waiting for database connection... ($ATTEMPTS)"
+	# wait for 5 seconds before check again
+	sleep 3
+done


### PR DESCRIPTION
@adamdecaf @vxio 

With this change:
1. We run single MySQL container that all tests use
2. Each test that calls `db := CreateTestMySQLDB` gets own unique database. On `db.Close()`database is dropped.
3. We don't stop / remove MySQL container as we don't know when all out tests are done

- [x] I created custom volume-less MySQL container that starts in 3s instead of 12s. I host it on own DockerHub public repo. It would be better to move under Moov's DockerHub account. @adamdecaf 

Using this changes reduces tests time for
* Customer's from 2m:30s to 28s (on my machine)
* Paygate's  from to 1m:10s to 30s (on my machine)