### PR TITLE
database: optimizing mysql

### DIFF
--- a/database/database.go
+++ b/database/database.go
@@ -11,11 +11,11 @@ import (
 // New establishes a database connection according to the type and environmental
 // variables for that specific database.
 func New(ctx context.Context, logger log.Logger, config Config) (*sql.DB, error) {
-	switch config.Type {
-	case TypeMySQL:
-		return mysqlConnection(logger, config.MySQL).Connect(ctx)
-	case TypeSQLite:
-		return sqliteConnection(logger, config.SQLite.Path).Connect(ctx)
+	switch c := config.(type) {
+	case MySQLConfig:
+		return mysqlConnection(logger, c).Connect(ctx)
+	case SQLiteConfig:
+		return sqliteConnection(logger, c.Path).Connect(ctx)
 	}
 
 	return nil, fmt.Errorf("database config not defined")

--- a/database/database.go
+++ b/database/database.go
@@ -10,17 +10,18 @@ import (
 
 // New establishes a database connection according to the type and environmental
 // variables for that specific database.
-func New(ctx context.Context, logger log.Logger, config DatabaseConfig) (*sql.DB, error) {
-	if config.MySQL != nil {
-		return mysqlConnection(logger, config.MySQL.User, config.MySQL.Password, config.MySQL.Address, config.DatabaseName).Connect(ctx)
-	} else if config.SQLite != nil {
+func New(ctx context.Context, logger log.Logger, config Config) (*sql.DB, error) {
+	switch config.Type {
+	case TypeMySQL:
+		return mysqlConnection(logger, config.MySQL).Connect(ctx)
+	case TypeSQLite:
 		return sqliteConnection(logger, config.SQLite.Path).Connect(ctx)
 	}
 
 	return nil, fmt.Errorf("database config not defined")
 }
 
-func NewAndMigrate(ctx context.Context, logger log.Logger, config DatabaseConfig) (*sql.DB, error) {
+func NewAndMigrate(ctx context.Context, logger log.Logger, config Config) (*sql.DB, error) {
 	if logger == nil {
 		logger = log.NewNopLogger()
 	}

--- a/database/database_test.go
+++ b/database/database_test.go
@@ -9,8 +9,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-
-	"github.com/moov-io/base/docker"
 )
 
 func Test_NewAndMigration_SQLite(t *testing.T) {
@@ -18,9 +16,12 @@ func Test_NewAndMigration_SQLite(t *testing.T) {
 	require.NoError(t, err)
 	defer os.RemoveAll(dir)
 
-	config := &DatabaseConfig{SQLite: &SQLiteConfig{
-		Path: filepath.Join(dir, "tests.db"),
-	}}
+	config := &Config{
+		Type: TypeSQLite,
+		SQLite: SQLiteConfig{
+			Path: filepath.Join(dir, "tests.db"),
+		},
+	}
 
 	db, err := NewAndMigrate(context.Background(), nil, *config)
 	require.NoError(t, err)
@@ -31,23 +32,28 @@ func Test_NewAndMigration_SQLite(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func Test_NewAndMigration_MySql(t *testing.T) {
-	if !docker.Enabled() {
-		t.SkipNow()
-	}
-
-	config, container, err := RunMySQLDockerInstance(&DatabaseConfig{})
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer container.Close()
-
-	db, err := NewAndMigrate(context.Background(), nil, *config)
-	if err != nil {
-		t.Fatal(err)
-	}
-	db.Close()
-}
+// func Test_NewAndMigration_MySql(t *testing.T) {
+// 	if !docker.Enabled() {
+// 		t.SkipNow()
+// 	}
+//
+// 	container, err := getMySQLDockerInstance(MySQLConfig{
+// 		Name:     "test",
+// 		Address:  "",
+// 		User:     "",
+// 		Password: "",
+// 	})
+// 	if err != nil {
+// 		t.Fatal(err)
+// 	}
+// 	defer container.Close()
+//
+// 	db, err := NewAndMigrate(context.Background(), nil, *config)
+// 	if err != nil {
+// 		t.Fatal(err)
+// 	}
+// 	db.Close()
+// }
 
 func TestUniqueViolation(t *testing.T) {
 	err := errors.New(`problem upserting depository="282f6ffcd9ba5b029afbf2b739ee826e22d9df3b", userId="f25f48968da47ef1adb5b6531a1c2197295678ce": Error 1062: Duplicate entry '282f6ffcd9ba5b029afbf2b739ee826e22d9df3b' for key 'PRIMARY'`)

--- a/database/database_test.go
+++ b/database/database_test.go
@@ -16,14 +16,11 @@ func Test_NewAndMigration_SQLite(t *testing.T) {
 	require.NoError(t, err)
 	defer os.RemoveAll(dir)
 
-	config := &Config{
-		Type: TypeSQLite,
-		SQLite: SQLiteConfig{
-			Path: filepath.Join(dir, "tests.db"),
-		},
+	config := SQLiteConfig{
+		Path: filepath.Join(dir, "tests.db"),
 	}
 
-	db, err := NewAndMigrate(context.Background(), nil, *config)
+	db, err := NewAndMigrate(context.Background(), nil, config)
 	require.NoError(t, err)
 	defer db.Close()
 

--- a/database/migrator.go
+++ b/database/migrator.go
@@ -33,7 +33,7 @@ func RunMigrations(logger log.Logger, config Config) error {
 
 	m, err := migrate.NewWithDatabaseInstance(
 		"pkger:///migrations/",
-		string(config.Type),
+		config.DBName(),
 		driver,
 	)
 	if err != nil {
@@ -55,10 +55,10 @@ func RunMigrations(logger log.Logger, config Config) error {
 }
 
 func GetDriver(db *sql.DB, config Config) (database.Driver, error) {
-	switch config.Type {
-	case TypeMySQL:
+	switch config.(type) {
+	case MySQLConfig:
 		return migmysql.WithInstance(db, &migmysql.Config{})
-	case TypeSQLite:
+	case SQLiteConfig:
 		return migsqlite3.WithInstance(db, &migsqlite3.Config{})
 	}
 

--- a/database/model_config.go
+++ b/database/model_config.go
@@ -1,12 +1,20 @@
 package database
 
-type DatabaseConfig struct {
-	MySQL        *MySQLConfig
-	SQLite       *SQLiteConfig
-	DatabaseName string
+type Type string
+
+const (
+	TypeMySQL  Type = "mysql"
+	TypeSQLite Type = "sqlite"
+)
+
+type Config struct {
+	Type   Type
+	MySQL  MySQLConfig
+	SQLite SQLiteConfig
 }
 
 type MySQLConfig struct {
+	Name     string
 	Address  string
 	User     string
 	Password string

--- a/database/model_config.go
+++ b/database/model_config.go
@@ -1,16 +1,12 @@
 package database
 
-type Type string
-
-const (
-	TypeMySQL  Type = "mysql"
-	TypeSQLite Type = "sqlite"
+import (
+	"path/filepath"
+	"strings"
 )
 
-type Config struct {
-	Type   Type
-	MySQL  MySQLConfig
-	SQLite SQLiteConfig
+type Config interface {
+	DBName() string
 }
 
 type MySQLConfig struct {
@@ -20,6 +16,15 @@ type MySQLConfig struct {
 	Password string
 }
 
+func (c MySQLConfig) DBName() string {
+	return c.Name
+}
+
 type SQLiteConfig struct {
 	Path string
+}
+
+func (c SQLiteConfig) DBName() string {
+	s := filepath.Base(c.Path)
+	return strings.TrimSuffix(s, filepath.Ext(s))
 }

--- a/database/mysql.go
+++ b/database/mysql.go
@@ -145,12 +145,6 @@ func CreateTestMySQLDB(t *testing.T) *TestMySQLDB {
 	// Don't allow idle connections so we can verify all are closed at the end of testing
 	db.SetMaxIdleConns(0)
 
-	// Run DB migrations
-	onceRunMigrations.Do(func() {
-		err = RunMigrations(log.NewNopLogger(), config)
-		require.NoError(t, err)
-	})
-
 	result := &TestMySQLDB{
 		DB:        db,
 		container: nil,
@@ -162,8 +156,16 @@ func CreateTestMySQLDB(t *testing.T) *TestMySQLDB {
 	t.Cleanup(func() {
 		dbMutex.Unlock()
 	})
+
+	onceRunMigrations.Do(func() {
+		// Run db migrations
+		err = RunMigrations(result.logger, config)
+		require.NoError(t, err)
+	})
+
 	// Teardown to ensure we're working with a clean DB
 	result.Teardown()
+
 	return result
 }
 

--- a/database/mysql.go
+++ b/database/mysql.go
@@ -96,6 +96,7 @@ func mysqlConnection(logger log.Logger, config MySQLConfig) *mysql {
 }
 
 var onceRunMigrations sync.Once
+var dbMutex sync.Mutex
 
 // CreateTestMySQLDB returns a TestMySQLDB which can be used in tests
 // as a clean mysql database. All migrations are ran on the db before.
@@ -156,9 +157,13 @@ func CreateTestMySQLDB(t *testing.T) *TestMySQLDB {
 		t:         t,
 		logger:    log.NewDefaultLogger(),
 	}
+
+	dbMutex.Lock()
+	t.Cleanup(func() {
+		dbMutex.Unlock()
+	})
 	// Teardown to ensure we're working with a clean DB
 	result.Teardown()
-
 	return result
 }
 

--- a/database/mysql.go
+++ b/database/mysql.go
@@ -110,27 +110,24 @@ func CreateTestMySQLDB(t *testing.T) *TestMySQLDB {
 		t.Skip("Docker not enabled")
 	}
 
-	config := Config{
-		Type: TypeMySQL,
-		MySQL: MySQLConfig{
-			Name:     "test",
-			User:     "moov",
-			Password: "secret",
-		},
+	config := MySQLConfig{
+		Name:     "test",
+		User:     "moov",
+		Password: "secret",
 	}
 
 	pool, err := dockertest.NewPool("")
 	require.NoError(t, err)
 
-	container, err := getMySQLDockerInstance(pool, "mysql-test-db", &config.MySQL)
+	container, err := getMySQLDockerInstance(pool, "mysql-test-db", &config)
 	require.NoError(t, err)
 
-	config.MySQL.Address = fmt.Sprintf("tcp(localhost:%s)", container.GetPort("3306/tcp"))
+	config.Address = fmt.Sprintf("tcp(localhost:%s)", container.GetPort("3306/tcp"))
 	dbURL := fmt.Sprintf("%s:%s@%s/%s",
-		config.MySQL.User,
-		config.MySQL.Password,
-		config.MySQL.Address,
-		config.MySQL.Name,
+		config.User,
+		config.Password,
+		config.Address,
+		config.Name,
 	)
 
 	var db *sql.DB

--- a/database/mysql_test.go
+++ b/database/mysql_test.go
@@ -21,23 +21,6 @@ func TestMySQL__Basic(t *testing.T) {
 	require.Equal(t, 0, db.DB.Stats().OpenConnections)
 }
 
-func TestMySQL_Teardown(t *testing.T) {
-	for i := 0; i < 3; i++ {
-		db := CreateTestMySQLDB(t)
-		defer db.Close()
-
-		row := db.QueryRow("SELECT COUNT(*) FROM tests")
-		var count int
-		require.NoError(t, row.Scan(&count))
-		require.Equal(t, 0, count)
-
-		insertQuery := "insert into tests (id) values (100),(200),(300);"
-		_, err := db.Exec(insertQuery)
-		require.NoError(t, err)
-	}
-
-}
-
 func TestMySQL_BadConnection(t *testing.T) {
 	// create a phony MySQL
 	m := mysqlConnection(log.NewNopLogger(), MySQLConfig{
@@ -68,8 +51,8 @@ func TestMySQLUniqueViolation(t *testing.T) {
 	}
 }
 
-func TestDatabaseMutex(t *testing.T) {
-	for i := 0; i < 30; i++ {
+func TestTeardown__Parallel(t *testing.T) {
+	for i := 0; i < 10; i++ {
 		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
 			t.Parallel()
 			db := CreateTestMySQLDB(t)

--- a/database/mysql_test.go
+++ b/database/mysql_test.go
@@ -3,7 +3,6 @@ package database
 import (
 	"context"
 	"errors"
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -31,7 +30,7 @@ func TestMySQL_Teardown(t *testing.T) {
 		require.NoError(t, row.Scan(&count))
 		require.Equal(t, 0, count)
 
-		insertQuery := fmt.Sprintf("insert into tests (id) values (100),(200),(300);")
+		insertQuery := "insert into tests (id) values (100),(200),(300);"
 		_, err := db.Exec(insertQuery)
 		require.NoError(t, err)
 	}

--- a/database/sqlite.go
+++ b/database/sqlite.go
@@ -122,9 +122,7 @@ func CreateTestSQLiteDB(t *testing.T) *TestSQLiteDB {
 
 	dbPath := filepath.Join(dir, "tests.db")
 
-	config := Config{
-		Type:   TypeSQLite,
-		SQLite: SQLiteConfig{Path: dbPath}}
+	config := SQLiteConfig{Path: dbPath}
 
 	logger := log.NewNopLogger()
 	ctx, cancelFunc := context.WithCancel(context.Background())

--- a/database/sqlite.go
+++ b/database/sqlite.go
@@ -122,14 +122,14 @@ func CreateTestSQLiteDB(t *testing.T) *TestSQLiteDB {
 
 	dbPath := filepath.Join(dir, "tests.db")
 
-	config := &DatabaseConfig{SQLite: &SQLiteConfig{
-		Path: dbPath,
-	}}
+	config := Config{
+		Type:   TypeSQLite,
+		SQLite: SQLiteConfig{Path: dbPath}}
 
 	logger := log.NewNopLogger()
 	ctx, cancelFunc := context.WithCancel(context.Background())
 
-	db, err := NewAndMigrate(ctx, logger, *config)
+	db, err := NewAndMigrate(ctx, logger, config)
 	if err != nil {
 		os.RemoveAll(dir)
 		t.Fatal(err)

--- a/go.sum
+++ b/go.sum
@@ -40,6 +40,8 @@ github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/ClickHouse/clickhouse-go v1.3.12/go.mod h1:EaI/sW7Azgz9UATzd5ZdZHRUhHgv5+JMS9NSr2smCJI=
+github.com/DATA-DOG/go-txdb v0.1.3 h1:R4v6OuOcy2O147e2zHxU0B4NDtF+INb5R9q/CV7AEMg=
+github.com/DATA-DOG/go-txdb v0.1.3/go.mod h1:DhAhxMXZpUJVGnT+p9IbzJoRKvlArO2pkHjnGX7o0n0=
 github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible/go.mod h1:r7JcOSlj0wfOMncg0iLm8Leh48TZaKVeNIfJntJ2wa0=
 github.com/Microsoft/go-winio v0.4.11/go.mod h1:VhR8bwka0BXejwEJY73c50VrPtXAaKcyvVC4A4RozmA=
 github.com/Microsoft/go-winio v0.4.14 h1:+hMXMk01us9KgxGb7ftKQt2Xpf5hH/yky+TDA+qxleU=


### PR DESCRIPTION
Draft/POC for @alovak and @adamdecaf from discussions at #119

Calling `db := CreateTestMySQLDB` does the following:
1. Get a mysql instance with the container name `mysql-test-db`
   - if the container doesn't exist, it will create one named `mysql-test-db`
   - we can add a config option if we want to use something other than `mysql-test-db`
1. Open a db connection and check that it works
1. Run migrations only once since it's wrapped in a `once.Do()`
1. Call `Teardown()` to ensure we're working with a clean DB

`dockertest` doesn't allow us to set the port number and uses a random one everytime, so we're using the `containerName` as the identifier.

Right now, parallel tests are not supported, so you shouldn't put `t.Parallel()` in tests where you're using `mysql`. Down the line, we can add support for booting up multiple mysql databases in the same instance as suggest by Adam in https://github.com/moov-io/base/pull/119#discussion_r514592858

 Here's a quick benchmark where we're calling `CreateTestMySQLDB()` in different tests. It'll run the teardown method each time in the same MySQL container.
![image](https://user-images.githubusercontent.com/29054071/97649528-c7483b80-1a14-11eb-93c8-f3754f7dca8b.png)

Also, I adjusted the database.Config APIs a bit and certain things still need to be refactored/validated. And I need to test this against some db tables in `customers`