### PR TITLE
Remove the interface{} from being a valid argument when deep down go-kit can error out.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @adamdecaf
+* @adamdecaf @infernojj

--- a/config/config.go
+++ b/config/config.go
@@ -16,7 +16,7 @@ type Service struct {
 
 func NewService(logger log.Logger) Service {
 	return Service{
-		logger: logger.Set("component", "Service"),
+		logger: logger.Set("component", log.String("Service")),
 	}
 }
 
@@ -27,7 +27,7 @@ func (s *Service) Load(config interface{}) error {
 	}
 
 	if file, ok := os.LookupEnv("APP_CONFIG"); ok && strings.TrimSpace(file) != "" {
-		logger := s.logger.Set("app_config", file)
+		logger := s.logger.Set("app_config", log.String(file))
 		logger.Info().Logf("Loading APP_CONFIG config file")
 
 		overrides := viper.New()
@@ -46,7 +46,7 @@ func (s *Service) Load(config interface{}) error {
 }
 
 func (s *Service) LoadFile(file string, config interface{}) error {
-	logger := s.logger.Set("file", file)
+	logger := s.logger.Set("file", log.String(file))
 	logger.Info().Logf("loading config file")
 
 	f, err := pkger.Open(file)

--- a/http/response.go
+++ b/http/response.go
@@ -60,11 +60,11 @@ func (w *ResponseWriter) WriteHeader(code int) {
 
 	if requestID := GetRequestID(w.request); requestID != "" && w.log != nil {
 		w.log.With(log.Fields{
-			"method":    w.request.Method,
-			"path":      w.request.URL.Path,
-			"status":    code,
-			"duration":  diff,
-			"requestID": requestID,
+			"method":    log.String(w.request.Method),
+			"path":      log.String(w.request.URL.Path),
+			"status":    log.Int(code),
+			"duration":  log.Duration(diff),
+			"requestID": log.String(requestID),
 		}).Send()
 	}
 }

--- a/http/response.go
+++ b/http/response.go
@@ -63,7 +63,7 @@ func (w *ResponseWriter) WriteHeader(code int) {
 			"method":    log.String(w.request.Method),
 			"path":      log.String(w.request.URL.Path),
 			"status":    log.Int(code),
-			"duration":  log.Duration(diff),
+			"duration":  log.TimeDuration(diff),
 			"requestID": log.String(requestID),
 		}).Send()
 	}

--- a/log/logger.go
+++ b/log/logger.go
@@ -1,7 +1,7 @@
 package log
 
 type Logger interface {
-	Set(key string, value interface{}) Logger
+	Set(key string, value Renderer) Logger
 	With(ctxs ...Context) Logger
 
 	Info() Logger
@@ -18,5 +18,5 @@ type Logger interface {
 }
 
 type Context interface {
-	Context() map[string]interface{}
+	Context() map[string]Renderer
 }

--- a/log/logger.go
+++ b/log/logger.go
@@ -1,7 +1,7 @@
 package log
 
 type Logger interface {
-	Set(key string, value Renderer) Logger
+	Set(key string, value Valuer) Logger
 	With(ctxs ...Context) Logger
 
 	Info() Logger
@@ -18,5 +18,5 @@ type Logger interface {
 }
 
 type Context interface {
-	Context() map[string]Renderer
+	Context() map[string]Valuer
 }

--- a/log/logger_impl.go
+++ b/log/logger_impl.go
@@ -31,7 +31,7 @@ func NewBufferLogger() (*strings.Builder, Logger) {
 func NewLogger(writer log.Logger) Logger {
 	l := &logger{
 		writer: writer,
-		ctx:    make(map[string]Renderer),
+		ctx:    make(map[string]Valuer),
 	}
 
 	// Default logs to be info until changed
@@ -42,10 +42,10 @@ var _ Logger = (*logger)(nil)
 
 type logger struct {
 	writer log.Logger
-	ctx    map[string]Renderer
+	ctx    map[string]Valuer
 }
 
-func (l *logger) Set(key string, value Renderer) Logger {
+func (l *logger) Set(key string, value Valuer) Logger {
 	return l.With(Fields{
 		key: value,
 	})
@@ -54,7 +54,7 @@ func (l *logger) Set(key string, value Renderer) Logger {
 // With returns a new Logger with the contexts added to its own.
 func (l *logger) With(ctxs ...Context) Logger {
 	// Estimation assuming that for each ctxs has at least 1 value.
-	combined := make(map[string]Renderer, len(l.ctx)+len(ctxs))
+	combined := make(map[string]Valuer, len(l.ctx)+len(ctxs))
 
 	for k, v := range l.ctx {
 		combined[k] = v

--- a/log/logger_impl.go
+++ b/log/logger_impl.go
@@ -31,7 +31,7 @@ func NewBufferLogger() (*strings.Builder, Logger) {
 func NewLogger(writer log.Logger) Logger {
 	l := &logger{
 		writer: writer,
-		ctx:    map[string]interface{}{},
+		ctx:    make(map[string]Renderer),
 	}
 
 	// Default logs to be info until changed
@@ -42,10 +42,10 @@ var _ Logger = (*logger)(nil)
 
 type logger struct {
 	writer log.Logger
-	ctx    map[string]interface{}
+	ctx    map[string]Renderer
 }
 
-func (l *logger) Set(key string, value interface{}) Logger {
+func (l *logger) Set(key string, value Renderer) Logger {
 	return l.With(Fields{
 		key: value,
 	})
@@ -54,7 +54,7 @@ func (l *logger) Set(key string, value interface{}) Logger {
 // With returns a new Logger with the contexts added to its own.
 func (l *logger) With(ctxs ...Context) Logger {
 	// Estimation assuming that for each ctxs has at least 1 value.
-	combined := make(map[string]interface{}, len(l.ctx)+len(ctxs))
+	combined := make(map[string]Renderer, len(l.ctx)+len(ctxs))
 
 	for k, v := range l.ctx {
 		combined[k] = v
@@ -105,7 +105,7 @@ func (l *logger) Log(msg string) {
 	i := len(orig)
 	for k, v := range l.ctx {
 		keyvals[i] = k
-		keyvals[i+1] = v
+		keyvals[i+1] = v.getValue()
 		i += 2
 	}
 
@@ -123,7 +123,7 @@ func (l *logger) Send() {
 }
 
 func (l *logger) LogError(err error) LoggedError {
-	l.Set("errored", "true").Log(err.Error())
+	l.Set("errored", Bool(true)).Log(err.Error())
 	return LoggedError{err}
 }
 

--- a/log/logger_test.go
+++ b/log/logger_test.go
@@ -42,7 +42,7 @@ func Test_LogWriteValue(t *testing.T) {
 	tests := []struct {
 		desc     string
 		key      string
-		val      lib.Renderer
+		val      lib.Valuer
 		expected string
 	}{
 		{

--- a/log/logger_test.go
+++ b/log/logger_test.go
@@ -1,7 +1,6 @@
-package log
+package log_test
 
 import (
-	"bytes"
 	"errors"
 	"fmt"
 	"regexp"
@@ -9,13 +8,14 @@ import (
 	"testing"
 	"time"
 
+	lib "github.com/moov-io/base/log"
 	"github.com/stretchr/testify/assert"
 )
 
 func Test_LogImplementations(t *testing.T) {
-	NewDefaultLogger()
-	NewNopLogger()
-	NewJSONLogger()
+	lib.NewDefaultLogger()
+	lib.NewNopLogger()
+	lib.NewJSONLogger()
 }
 
 func Test_Log(t *testing.T) {
@@ -42,27 +42,22 @@ func Test_LogWriteValue(t *testing.T) {
 	tests := []struct {
 		desc     string
 		key      string
-		val      interface{}
+		val      lib.Renderer
 		expected string
 	}{
 		{
 			key:      "foo",
-			val:      []byte("bar"),
+			val:      lib.ByteString([]byte("bar")),
 			expected: "foo=bar",
 		},
 		{
 			key:      "foo",
-			val:      bytes.NewBufferString("bar"),
+			val:      lib.String(errors.New("bar").Error()),
 			expected: "foo=bar",
 		},
 		{
 			key:      "foo",
-			val:      errors.New("bar"),
-			expected: "foo=bar",
-		},
-		{
-			key:      "foo",
-			val:      100,
+			val:      lib.Int(100),
 			expected: "foo=100",
 		},
 	}
@@ -76,7 +71,7 @@ func Test_LogWriteValue(t *testing.T) {
 
 func Test_Send(t *testing.T) {
 	a, buffer, log := Setup(t)
-	log.Set("foo", "bar").Send()
+	log.Set("foo", lib.String("bar")).Send()
 
 	got := buffer.String()
 	a.NotContains(got, "msg=")
@@ -87,7 +82,7 @@ func Test_Send(t *testing.T) {
 func Test_WithContext(t *testing.T) {
 	a, buffer, log := Setup(t)
 
-	log.With(Error).Logf("my error message")
+	log.With(lib.Error).Logf("my error message")
 
 	a.Contains(buffer.String(), "level=error")
 }
@@ -95,7 +90,7 @@ func Test_WithContext(t *testing.T) {
 func Test_ReplaceContextValue(t *testing.T) {
 	a, buffer, log := Setup(t)
 
-	log.With(Error).With(Info).Logf("my error message")
+	log.With(lib.Error).With(lib.Info).Logf("my error message")
 
 	a.Contains(buffer.String(), "level=info")
 }
@@ -137,7 +132,7 @@ func Test_Fatal(t *testing.T) {
 func Test_CustomKeyValue(t *testing.T) {
 	a, buffer, log := Setup(t)
 
-	log.Set("custom", "value").Logf("test")
+	log.Set("custom", lib.String("value")).Logf("test")
 
 	a.Contains(buffer.String(), "custom=value")
 }
@@ -145,9 +140,9 @@ func Test_CustomKeyValue(t *testing.T) {
 func Test_CustomMap(t *testing.T) {
 	a, buffer, log := Setup(t)
 
-	log.With(Fields{
-		"custom1": "value1",
-		"custom2": "value2",
+	log.With(lib.Fields{
+		"custom1": lib.String("value1"),
+		"custom2": lib.String("value2"),
 	}).Logf("test")
 
 	output := buffer.String()
@@ -159,8 +154,8 @@ func Test_MultipleContexts(t *testing.T) {
 	a, buffer, log := Setup(t)
 
 	log.
-		Set("custom1", "value1").
-		Set("custom2", "value2").
+		Set("custom1", lib.String("value1")).
+		Set("custom2", lib.String("value2")).
 		Logf("test")
 
 	output := buffer.String()
@@ -187,12 +182,12 @@ func Test_LogError(t *testing.T) {
 func Test_Caller(t *testing.T) {
 	a, buffer, log := Setup(t)
 
-	log.Info().With(stacktrace).Logf("message")
+	log.Info().With(lib.StackTrace).Logf("message")
 	a.Regexp(regexp.MustCompile(`caller_0=(.*?)(\/log\/logger_test\.go)`), buffer.String())
 }
 
-func Setup(t *testing.T) (*assert.Assertions, *strings.Builder, Logger) {
+func Setup(t *testing.T) (*assert.Assertions, *strings.Builder, lib.Logger) {
 	a := assert.New(t)
-	buffer, log := NewBufferLogger()
+	buffer, log := lib.NewBufferLogger()
 	return a, buffer, log
 }

--- a/log/logger_test.go
+++ b/log/logger_test.go
@@ -52,7 +52,7 @@ func Test_LogWriteValue(t *testing.T) {
 		},
 		{
 			key:      "foo",
-			val:      lib.Bytes64([]byte("bar")),
+			val:      lib.ByteBase64([]byte("bar")),
 			expected: "foo=YmFy",
 		},
 		{
@@ -82,17 +82,17 @@ func Test_LogWriteValue(t *testing.T) {
 		},
 		{
 			key:      "foo",
-			val:      lib.Duration(time.Duration(1)),
+			val:      lib.TimeDuration(time.Duration(1)),
 			expected: "foo=1ns",
 		},
 		{
 			key:      "foo",
-			val:      lib.Timestamp(time.Unix(0, 0)),
+			val:      lib.Time(time.Unix(0, 0)),
 			expected: "foo=1969-12-31T18:00:00-06:00",
 		},
 		{
 			key:      "foo",
-			val:      lib.TimestampFormat(time.Unix(0, 0), time.RFC822),
+			val:      lib.TimeFormatted(time.Unix(0, 0), time.RFC822),
 			expected: "foo=\"31 Dec 69 18:00 CST\"",
 		},
 	}

--- a/log/logger_test.go
+++ b/log/logger_test.go
@@ -87,8 +87,8 @@ func Test_LogWriteValue(t *testing.T) {
 		},
 		{
 			key:      "foo",
-			val:      lib.Time(time.Unix(0, 0)),
-			expected: "foo=1969-12-31T18:00:00-06:00",
+			val:      lib.Time(time.Unix(0, 0).UTC()),
+			expected: "foo=1970-01-01T00:00:00Z",
 		},
 		{
 			key:      "foo",

--- a/log/logger_test.go
+++ b/log/logger_test.go
@@ -52,6 +52,11 @@ func Test_LogWriteValue(t *testing.T) {
 		},
 		{
 			key:      "foo",
+			val:      lib.Bytes64([]byte("bar")),
+			expected: "foo=YmFy",
+		},
+		{
+			key:      "foo",
 			val:      lib.String(errors.New("bar").Error()),
 			expected: "foo=bar",
 		},
@@ -59,6 +64,36 @@ func Test_LogWriteValue(t *testing.T) {
 			key:      "foo",
 			val:      lib.Int(100),
 			expected: "foo=100",
+		},
+		{
+			key:      "foo",
+			val:      lib.String("bleh"),
+			expected: "foo=bleh",
+		},
+		{
+			key:      "foo",
+			val:      lib.Float64(0.001),
+			expected: "foo=0.001",
+		},
+		{
+			key:      "foo",
+			val:      lib.Bool(true),
+			expected: "foo=true",
+		},
+		{
+			key:      "foo",
+			val:      lib.Duration(time.Duration(1)),
+			expected: "foo=1ns",
+		},
+		{
+			key:      "foo",
+			val:      lib.Timestamp(time.Unix(0, 0)),
+			expected: "foo=1969-12-31T18:00:00-06:00",
+		},
+		{
+			key:      "foo",
+			val:      lib.TimestampFormat(time.Unix(0, 0), time.RFC822),
+			expected: "foo=\"31 Dec 69 18:00 CST\"",
 		},
 	}
 	for _, tc := range tests {

--- a/log/logger_test.go
+++ b/log/logger_test.go
@@ -125,9 +125,9 @@ func Test_WithContext(t *testing.T) {
 func Test_ReplaceContextValue(t *testing.T) {
 	a, buffer, log := Setup(t)
 
-	log.With(lib.Error).With(lib.Info).Logf("my error message")
+	log.With(lib.Error).Warn().Logf("my error message")
 
-	a.Contains(buffer.String(), "level=info")
+	a.Contains(buffer.String(), "level=warn")
 }
 
 func Test_Info(t *testing.T) {

--- a/log/logger_test.go
+++ b/log/logger_test.go
@@ -92,8 +92,8 @@ func Test_LogWriteValue(t *testing.T) {
 		},
 		{
 			key:      "foo",
-			val:      lib.TimeFormatted(time.Unix(0, 0), time.RFC822),
-			expected: "foo=\"31 Dec 69 18:00 CST\"",
+			val:      lib.TimeFormatted(time.Unix(0, 0).UTC(), time.RFC822),
+			expected: "foo=\"01 Jan 70 00:00 UTC\"",
 		},
 	}
 	for _, tc := range tests {

--- a/log/model_fields.go
+++ b/log/model_fields.go
@@ -1,7 +1,7 @@
 package log
 
-type Fields map[string]interface{}
+type Fields map[string]Renderer
 
-func (f Fields) Context() map[string]interface{} {
+func (f Fields) Context() map[string]Renderer {
 	return f
 }

--- a/log/model_fields.go
+++ b/log/model_fields.go
@@ -1,7 +1,7 @@
 package log
 
-type Fields map[string]Renderer
+type Fields map[string]Valuer
 
-func (f Fields) Context() map[string]Renderer {
+func (f Fields) Context() map[string]Valuer {
 	return f
 }

--- a/log/model_formats.go
+++ b/log/model_formats.go
@@ -1,0 +1,57 @@
+package log
+
+import (
+	"encoding/base64"
+	"time"
+)
+
+// Renderer is an interface to deal with typing problems of just having an interface{} as the acceptable parameters
+// Go-kit logging has a failure case if you attempt to throw any values into it.
+// This is a way to guard our developers from having to worry about error cases of the lower logging framework.
+type Renderer interface {
+	getValue() interface{}
+}
+
+type any struct {
+	value interface{}
+}
+
+func (a *any) getValue() interface{} {
+	return a.value
+}
+
+func String(s string) Renderer {
+	return &any{s}
+}
+
+func Int(i int) Renderer {
+	return &any{i}
+}
+
+func Float64(f float64) Renderer {
+	return &any{f}
+}
+
+func Bool(b bool) Renderer {
+	return &any{b}
+}
+
+func Duration(d time.Duration) Renderer {
+	return &any{d.String()}
+}
+
+func Timestamp(t time.Time) Renderer {
+	return TimestampFormat(t, time.RFC3339Nano)
+}
+
+func TimestampFormat(t time.Time, format string) Renderer {
+	return String(t.Format(format))
+}
+
+func ByteString(b []byte) Renderer {
+	return String(string(b))
+}
+
+func Bytes64(b []byte) Renderer {
+	return String(base64.RawURLEncoding.EncodeToString(b))
+}

--- a/log/model_formats.go
+++ b/log/model_formats.go
@@ -36,15 +36,15 @@ func Bool(b bool) Renderer {
 	return &any{b}
 }
 
-func Duration(d time.Duration) Renderer {
+func TimeDuration(d time.Duration) Renderer {
 	return &any{d.String()}
 }
 
-func Timestamp(t time.Time) Renderer {
-	return TimestampFormat(t, time.RFC3339Nano)
+func Time(t time.Time) Renderer {
+	return TimeFormatted(t, time.RFC3339Nano)
 }
 
-func TimestampFormat(t time.Time, format string) Renderer {
+func TimeFormatted(t time.Time, format string) Renderer {
 	return String(t.Format(format))
 }
 
@@ -52,6 +52,6 @@ func ByteString(b []byte) Renderer {
 	return String(string(b))
 }
 
-func Bytes64(b []byte) Renderer {
+func ByteBase64(b []byte) Renderer {
 	return String(base64.RawURLEncoding.EncodeToString(b))
 }

--- a/log/model_levels.go
+++ b/log/model_levels.go
@@ -6,6 +6,7 @@ type Level string
 // Info is sets level=info in the log output
 const Info = Level("info")
 
+// Info is sets level=warn in the log output
 const Warn = Level("warn")
 
 // Error sets level=error in the log output
@@ -15,8 +16,8 @@ const Error = Level("error")
 const Fatal = Level("fatal")
 
 // Context returns the map that states that key value of `level={{l}}`
-func (l Level) Context() map[string]interface{} {
-	return map[string]interface{}{
-		"level": string(l),
+func (l Level) Context() map[string]Renderer {
+	return map[string]Renderer{
+		"level": String(string(l)),
 	}
 }

--- a/log/model_levels.go
+++ b/log/model_levels.go
@@ -16,8 +16,8 @@ const Error = Level("error")
 const Fatal = Level("fatal")
 
 // Context returns the map that states that key value of `level={{l}}`
-func (l Level) Context() map[string]Renderer {
-	return map[string]Renderer{
+func (l Level) Context() map[string]Valuer {
+	return map[string]Valuer{
 		"level": String(string(l)),
 	}
 }

--- a/log/model_stacktrace.go
+++ b/log/model_stacktrace.go
@@ -8,11 +8,11 @@ import (
 
 type st string
 
-const stacktrace = st("stacktrace")
+const StackTrace = st("stacktrace")
 
 // Context returns the map that states that key value of `level={{l}}`
-func (s st) Context() map[string]interface{} {
-	kv := map[string]interface{}{}
+func (s st) Context() map[string]Renderer {
+	kv := map[string]Renderer{}
 
 	i := 0
 	c := 0
@@ -21,7 +21,7 @@ func (s st) Context() map[string]interface{} {
 		if c > 0 || (!strings.HasSuffix(file, "model_stacktrace.go") && !strings.HasSuffix(file, "logger_impl.go")) {
 			key := fmt.Sprintf("caller_%d", c)
 			value := fmt.Sprintf("%s:%d", file, line)
-			kv[key] = value
+			kv[key] = String(value)
 			c++
 		}
 		_, file, line, ok = runtime.Caller(i + 1)

--- a/log/model_stacktrace.go
+++ b/log/model_stacktrace.go
@@ -11,8 +11,8 @@ type st string
 const StackTrace = st("stacktrace")
 
 // Context returns the map that states that key value of `level={{l}}`
-func (s st) Context() map[string]Renderer {
-	kv := map[string]Renderer{}
+func (s st) Context() map[string]Valuer {
+	kv := map[string]Valuer{}
 
 	i := 0
 	c := 0

--- a/log/model_valuer.go
+++ b/log/model_valuer.go
@@ -5,10 +5,10 @@ import (
 	"time"
 )
 
-// Renderer is an interface to deal with typing problems of just having an interface{} as the acceptable parameters
+// Valuer is an interface to deal with typing problems of just having an interface{} as the acceptable parameters
 // Go-kit logging has a failure case if you attempt to throw any values into it.
 // This is a way to guard our developers from having to worry about error cases of the lower logging framework.
-type Renderer interface {
+type Valuer interface {
 	getValue() interface{}
 }
 
@@ -20,38 +20,38 @@ func (a *any) getValue() interface{} {
 	return a.value
 }
 
-func String(s string) Renderer {
+func String(s string) Valuer {
 	return &any{s}
 }
 
-func Int(i int) Renderer {
+func Int(i int) Valuer {
 	return &any{i}
 }
 
-func Float64(f float64) Renderer {
+func Float64(f float64) Valuer {
 	return &any{f}
 }
 
-func Bool(b bool) Renderer {
+func Bool(b bool) Valuer {
 	return &any{b}
 }
 
-func TimeDuration(d time.Duration) Renderer {
+func TimeDuration(d time.Duration) Valuer {
 	return &any{d.String()}
 }
 
-func Time(t time.Time) Renderer {
+func Time(t time.Time) Valuer {
 	return TimeFormatted(t, time.RFC3339Nano)
 }
 
-func TimeFormatted(t time.Time, format string) Renderer {
+func TimeFormatted(t time.Time, format string) Valuer {
 	return String(t.Format(format))
 }
 
-func ByteString(b []byte) Renderer {
+func ByteString(b []byte) Valuer {
 	return String(string(b))
 }
 
-func ByteBase64(b []byte) Renderer {
+func ByteBase64(b []byte) Valuer {
 	return String(base64.RawURLEncoding.EncodeToString(b))
 }


### PR DESCRIPTION
Remove the interface{} from being a valid argument when deep down go-kit can error out.