### PR TITLE
api: use a clearer default error example

### DIFF
--- a/api/common.yaml
+++ b/api/common.yaml
@@ -15,4 +15,4 @@ components:
         error:
           type: string
           description: An error message describing the problem intended for humans.
-          example: Validation error(s) present.
+          example: Example error, see description


### PR DESCRIPTION
This Error type is used in every API endpoint and so it was a bit
unclear and messy when looking at endpoints that don't really validate
fields. Instead let's use explicit filler text.