### PR TITLE
Allow timezone to be passed to time Now

### DIFF
--- a/time.go
+++ b/time.go
@@ -37,8 +37,7 @@ type Time struct {
 }
 
 // Now returns a Time object with the current clock time set.
-// By default, America/New_York will be the chosen time zone.
-func Now() Time {
+func Now(location *time.Location) Time {
 	// Create our calendar to attach on Time
 	calendar := cal.NewCalendar()
 	cal.AddUsHolidays(calendar)
@@ -46,7 +45,7 @@ func Now() Time {
 
 	return Time{
 		cal:  calendar,
-		Time: time.Now().UTC().Truncate(1 * time.Second),
+		Time: time.Now().In(location).Truncate(1 * time.Second),
 	}
 }
 

--- a/time.go
+++ b/time.go
@@ -57,7 +57,7 @@ func Now(location *time.Location) Time {
 // now := Now()
 // fmt.Println(start.Sub(now.Time))
 func NewTime(t time.Time) Time {
-	tt := Now()
+	tt := Now(time.UTC)
 	tt.Time = t.UTC() // overwrite underlying Time
 	return tt
 }

--- a/time_test.go
+++ b/time_test.go
@@ -25,7 +25,7 @@ func init() {
 }
 
 func TestTime(t *testing.T) {
-	t1 := Now()
+	t1 := Now(time.UTC)
 
 	// Verify time.Time methods work
 	if diff := t1.Sub(t1.Time); diff != 0 {
@@ -43,13 +43,13 @@ func TestTime__NewTime(t *testing.T) {
 	start := time.Now().Add(-1 * time.Second)
 
 	// Example from NewTime godoc
-	now := Now()
+	now := Now(time.UTC)
 	fmt.Println(start.Sub(now.Time))
 }
 
 func TestTime__JSON(t *testing.T) {
 	// marshal and then unmarshal
-	t1 := Now()
+	t1 := Now(time.UTC)
 
 	bs, err := t1.MarshalJSON()
 	if err != nil {


### PR DESCRIPTION
Allowing a timezone to be passed to `Now`. This is important since `IsBankingDay` and `IsWeekend` are timezone specific.