### PR TITLE
Adding in a .Nil() method to the logged error

### DIFF
--- a/log/logger_impl.go
+++ b/log/logger_impl.go
@@ -140,3 +140,7 @@ type LoggedError struct {
 func (l LoggedError) Err() error {
 	return l.err
 }
+
+func (l LoggedError) Nil() error {
+	return nil
+}


### PR DESCRIPTION
Adding in a .Nil() method to the logged error so you can log and return nil in the same oneliner