### PR TITLE
add subrouter function to Server

### DIFF
--- a/admin/admin.go
+++ b/admin/admin.go
@@ -101,6 +101,23 @@ func (s *Server) AddVersionHandler(version string) {
 	})
 }
 
+// Subrouter creates and returns a subrouter with the specific prefix.
+//
+// The returned subrouter can Use() middleware without impacting
+// the parent router. For example:
+//
+// 	  svr := NewServer(":8080")
+//	  subRouter := svr.Subrouter("/prefix")
+//    subRouter.Use(someMiddleware)
+// 	  subRouter.HandleFunc("/resource", ResourceHandler)
+//
+// Here, requests for "/prefix/resource" would go through someMiddleware while
+// the liveliness and readiness routes added to the parent router by NewServer()
+// would not.
+func (s *Server) Subrouter(pathPrefix string) *mux.Router {
+	return s.router.PathPrefix(pathPrefix).Subrouter()
+}
+
 // profileEnabled returns if a given pprof handler should be
 // enabled according to pprofHandlers and the PPROF_* environment
 // variables.

--- a/admin/admin.go
+++ b/admin/admin.go
@@ -103,7 +103,7 @@ func (s *Server) AddVersionHandler(version string) {
 
 // Subrouter creates and returns a subrouter with the specific prefix.
 //
-// The returned subrouter can Use() middleware without impacting
+// The returned subrouter can use middleware without impacting
 // the parent router. For example:
 //
 //     svr := NewServer(":8080")

--- a/admin/admin.go
+++ b/admin/admin.go
@@ -106,10 +106,10 @@ func (s *Server) AddVersionHandler(version string) {
 // The returned subrouter can Use() middleware without impacting
 // the parent router. For example:
 //
-// 	  svr := NewServer(":8080")
-//	  subRouter := svr.Subrouter("/prefix")
-//    subRouter.Use(someMiddleware)
-// 	  subRouter.HandleFunc("/resource", ResourceHandler)
+//     svr := NewServer(":8080")
+//     subRouter := svr.Subrouter("/prefix")
+//     subRouter.Use(someMiddleware)
+//     subRouter.HandleFunc("/resource", ResourceHandler)
 //
 // Here, requests for "/prefix/resource" would go through someMiddleware while
 // the liveliness and readiness routes added to the parent router by NewServer()


### PR DESCRIPTION
This PR adds a function to the `Server` struct that creates a path prefixed subrouter. This enables users to use different middlewares for different route groups.