### PR TITLE
Support go embed

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,6 +1,7 @@
 package config_test
 
 import (
+	"embed"
 	"os"
 	"testing"
 
@@ -17,6 +18,7 @@ type ConfigModel struct {
 	Default string
 	App     string
 	Secret  string
+	Custom  string
 }
 
 func Test_Load(t *testing.T) {
@@ -36,4 +38,21 @@ func Test_Load(t *testing.T) {
 	require.Equal(t, "default", cfg.Config.Default)
 	require.Equal(t, "app", cfg.Config.App)
 	require.Equal(t, "keep secret!", cfg.Config.Secret)
+}
+
+//go:embed testdata/*.yml
+var configs embed.FS
+
+func Test_LoadFile(t *testing.T) {
+	cfg := &GlobalConfigModel{}
+
+	service := config.NewService(log.NewDefaultLogger())
+
+	file, err := configs.Open("testdata/config.yml")
+	require.NoError(t, err)
+
+	err = service.LoadFromReader(file, cfg)
+	require.NoError(t, err)
+
+	require.Equal(t, "custom", cfg.Config.Custom)
 }

--- a/config/testdata/config.yml
+++ b/config/testdata/config.yml
@@ -1,0 +1,2 @@
+Config:
+  Custom: "custom"

--- a/database/database.go
+++ b/database/database.go
@@ -35,7 +35,7 @@ func NewAndMigrate(ctx context.Context, logger log.Logger, config DatabaseConfig
 	}
 
 	// run migrations first
-	if err := RunMigrations(logger, config); err != nil {
+	if err := RunMigrations(logger, config, nil); err != nil {
 		return nil, err
 	}
 

--- a/database/migrator.go
+++ b/database/migrator.go
@@ -17,7 +17,7 @@ import (
 
 var migrationMutex sync.Mutex
 
-func RunMigrations(logger log.Logger, config DatabaseConfig) error {
+func RunMigrations(logger log.Logger, config DatabaseConfig, migrationsSource source.Driver) error {
 	db, err := New(context.Background(), logger, config)
 	if err != nil {
 		return err
@@ -33,8 +33,8 @@ func RunMigrations(logger log.Logger, config DatabaseConfig) error {
 
 	migrationMutex.Lock()
 	m, err := migrate.NewWithInstance(
-		"filtering-pkger",
-		source,
+		"iofs",
+		migrationsSource,
 		config.DatabaseName,
 		driver,
 	)

--- a/database/migrator.go
+++ b/database/migrator.go
@@ -31,10 +31,14 @@ func RunMigrations(logger log.Logger, config DatabaseConfig, migrationsSource so
 		return err
 	}
 
+	if migrationsSource != nil {
+		source = migrationsSource
+	}
+
 	migrationMutex.Lock()
 	m, err := migrate.NewWithInstance(
 		"iofs",
-		migrationsSource,
+		source,
 		config.DatabaseName,
 		driver,
 	)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/moov-io/base
 
-go 1.13
+go 1.16
 
 require (
 	github.com/go-kit/kit v0.10.0


### PR DESCRIPTION
The goal of this PR is to switch Moov's projects from `pkger` to `go:embed` for default config and migrations.

# Why?

* `pkger` is an external dependency that currently adds external steps in dev setup, compilation, etc. it creates unnecessary friction
* `pkger` raises some unnecessary questions like: should we store `pkged.go` in repository or no? (the answer is **no**, but in some repositories we still have it)
* starting from v 1.16 golang supports file embedding

# Some context:
* golang-migrate/migrate added support for io.FS and embed, but then reverted it and soon will get it back (in short, go 1.15 had some issues with `go:embed` and `go mod tidy`, it was fixed, but `golang-migrate` team decided to wait for a little and git time to users to switch to fixed go version) here are more details: the https://github.com/golang-migrate/migrate/issues/471 
* until that issue solved, there is a [separate driver](https://github.com/johejo/golang-migrate-extra) for go `io.fs` which we are using in the PR

# Concerns / Questions
* Should we still support `pkger` for previous projects? Or I can remove it completely?