### PR TITLE
database: mask mysql password in JSON marshaling

### DIFF
--- a/database/model_config.go
+++ b/database/model_config.go
@@ -1,6 +1,11 @@
 package database
 
-import "time"
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/moov-io/base/mask"
+)
 
 type DatabaseConfig struct {
 	MySQL        *MySQLConfig
@@ -13,6 +18,21 @@ type MySQLConfig struct {
 	User        string
 	Password    string
 	Connections ConnectionsConfig
+}
+
+func (m *MySQLConfig) MarshalJSON() ([]byte, error) {
+	type Aux struct {
+		Address     string
+		User        string
+		Password    string
+		Connections ConnectionsConfig
+	}
+	return json.Marshal(Aux{
+		Address:     m.Address,
+		User:        m.User,
+		Password:    mask.Password(m.Password),
+		Connections: m.Connections,
+	})
 }
 
 type SQLiteConfig struct {

--- a/database/model_config_test.go
+++ b/database/model_config_test.go
@@ -1,0 +1,25 @@
+package database
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMySQLConfig(t *testing.T) {
+	cfg := &MySQLConfig{
+		Address:  "tcp(localhost:3306)",
+		User:     "app",
+		Password: "secret",
+		Connections: ConnectionsConfig{
+			MaxOpen: 100,
+		},
+	}
+
+	var buf bytes.Buffer
+	err := json.NewEncoder(&buf).Encode(cfg)
+	require.NoError(t, err)
+	require.Contains(t, buf.String(), `"Password":"s*****t"`)
+}

--- a/mask/password.go
+++ b/mask/password.go
@@ -1,0 +1,20 @@
+// Copyright 2020 The Moov Authors
+// Use of this source code is governed by an Apache License
+// license that can be found in the LICENSE file.
+
+package mask
+
+import (
+	"fmt"
+	"unicode/utf8"
+)
+
+func Password(s string) string {
+	if utf8.RuneCountInString(s) < 5 {
+		return "*****" // too short, we can't mask anything
+	} else {
+		// turn 'password' into 'p*****d'
+		first, last := s[0:1], s[len(s)-1:]
+		return fmt.Sprintf("%s*****%s", first, last)
+	}
+}

--- a/mask/password_test.go
+++ b/mask/password_test.go
@@ -1,0 +1,27 @@
+// Copyright 2020 The Moov Authors
+// Use of this source code is governed by an Apache License
+// license that can be found in the LICENSE file.
+
+package mask
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMaskPassword(t *testing.T) {
+	cases := []struct {
+		input, expected string
+	}{
+		{"", "*****"},
+		{"ab", "*****"},
+		{"abcde", "a*****e"},
+		{"123456", "1*****6"},
+		{"password", "p*****d"},
+	}
+	for i := range cases {
+		output := Password(cases[i].input)
+		require.Equal(t, cases[i].expected, output)
+	}
+}


### PR DESCRIPTION
This is useful to hide passwords with `GET /config` on admin servers. 