### PR TITLE
unexpected behaviour AddBankingDay

### DIFF
--- a/time.go
+++ b/time.go
@@ -118,13 +118,19 @@ func (t Time) IsBankingDay() bool {
 	return true
 }
 
-// AddBankingDay takes an integer for the number of valid banking days to add and returns a Time
+// AddBankingDay takes an integer for the number of valid banking days to add and returns a Time.
+// Negative values and large values (over 500 days) will not modify the Time.
 func (t Time) AddBankingDay(d int) Time {
-	t.Time = t.Time.AddDate(0, 0, d)
-	if !t.IsBankingDay() {
-		return t.AddBankingDay(1)
+	if d < 1 || d > 500 {
+		return t
 	}
-	return t
+
+	t.Time = t.Time.AddDate(0, 0, 1)
+	if t.IsBankingDay() {
+		return t.AddBankingDay(d - 1)
+	}
+
+	return t.AddBankingDay(d)
 }
 
 // IsWeekend reports whether the given date falls on a weekend.

--- a/time_test.go
+++ b/time_test.go
@@ -227,6 +227,7 @@ func TestTime__IsWeekend(t *testing.T) {
 }
 
 func TestTime_AddBankingDay(t *testing.T) {
+	unchangeable := time.Date(2021, time.July, 15, 1, 0, 0, 0, est)
 	tests := []struct {
 		Date   time.Time
 		Future time.Time
@@ -240,6 +241,17 @@ func TestTime_AddBankingDay(t *testing.T) {
 		{time.Date(2018, time.January, 12, 1, 0, 0, 0, est), time.Date(2018, time.January, 17, 1, 0, 0, 0, est), 2},
 		// Friday add two days over a sunday public holiday (moved to monday) needs to be following wednesday
 		{time.Date(2021, time.July, 2, 1, 0, 0, 0, est), time.Date(2021, time.July, 7, 1, 0, 0, 0, est), 2},
+		// Negative input
+		{unchangeable, unchangeable, 0},
+		{unchangeable, unchangeable, -1},
+		{unchangeable, unchangeable, -10},
+		// Input above the max
+		{unchangeable, unchangeable, 501},
+		{unchangeable, unchangeable, 600},
+		// Input at the max
+		{time.Date(2021, time.July, 2, 1, 0, 0, 0, est), time.Date(2023, time.June, 28, 1, 0, 0, 0, est), 500},
+		// Find one year in the future
+		{time.Date(2021, time.July, 2, 1, 0, 0, 0, est), time.Date(2022, time.June, 28, 1, 0, 0, 0, est), 365 - 12 - (52 * 2)},
 	}
 	for _, test := range tests {
 		actual := NewTime(test.Date).AddBankingDay(test.Days)

--- a/time_test.go
+++ b/time_test.go
@@ -232,18 +232,24 @@ func TestTime_AddBankingDay(t *testing.T) {
 		Future time.Time
 		Days   int
 	}{
-		// Thursday add two days over a monday holiday abd needs to be following tuesday
+		// Thursday add one day needs to be friday
+		{time.Date(2018, time.January, 11, 1, 0, 0, 0, est), time.Date(2018, time.January, 12, 1, 0, 0, 0, est), 1},
+		// Thursday add two days over a monday holiday and needs to be following tuesday
 		{time.Date(2018, time.January, 11, 1, 0, 0, 0, est), time.Date(2018, time.January, 16, 1, 0, 0, 0, est), 2},
+		// Friday add two days over a monday holiday abd needs to be following wednesday
+		{time.Date(2018, time.January, 12, 1, 0, 0, 0, est), time.Date(2018, time.January, 17, 1, 0, 0, 0, est), 2},
+		// Friday add two days over a sunday public holiday (moved to monday) needs to be following wednesday
+		{time.Date(2021, time.July, 2, 1, 0, 0, 0, est), time.Date(2021, time.July, 7, 1, 0, 0, 0, est), 2},
 	}
 	for _, test := range tests {
 		actual := NewTime(test.Date).AddBankingDay(test.Days)
 		if !actual.Equal(NewTime(test.Future)) {
-			t.Errorf("Adding %d days: expected %s, got %s", test.Days, test.Future.Weekday().String(), actual)
+			t.Errorf("Adding %d days: expected %s, got %s", test.Days, NewTime(test.Future), actual)
 		}
 
 		actual = NewTime(test.Date).AddBankingDay(test.Days)
 		if !actual.Equal(NewTime(test.Future)) {
-			t.Errorf("Adding %d days: expected %s, got %s", test.Days, test.Future.Weekday().String(), actual)
+			t.Errorf("Adding %d days: expected %s, got %s", test.Days, NewTime(test.Future), actual)
 		}
 	}
 }


### PR DESCRIPTION
PayGate Version: `0.10.3`

**What were you trying to do?**
Coming from Paygate, the Effective Entry Date of an ACH entry was not calculated properly over weekends and was caught by Bank Validations
related: https://github.com/moov-io/paygate/pull/644

**What did you expect to see?**
Given any friday
`t.AddBankingDay(2)` adds 2 banking days to given date (monday, tuesday) and should return tuesday

**What did you see?**
`t.AddBankingDay(2)` adds 2 days to given date and if the date is still a holiday it adds 1 banking day recursively
This means the code doesnt check if the first added day is banking day or not

**How can we reproduce the problem?**
added failing test cases