### PR TITLE
add WithPrefix for prefixed logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v0.23.0 (Released 2021-08-11)
+
+IMPROVEMENTS
+
+- log: added WithPrefix method for persistence contextual logging
+
 ## v0.22.0 (Released 2021-08-09)
 
 IMPROVEMENTS

--- a/log/logger.go
+++ b/log/logger.go
@@ -2,6 +2,7 @@ package log
 
 type Logger interface {
 	Set(key string, value Valuer) Logger
+	WithPrefix(ctxs ...Context) Logger
 	With(ctxs ...Context) Logger
 
 	Debug() Logger

--- a/log/logger_impl.go
+++ b/log/logger_impl.go
@@ -51,6 +51,21 @@ func (l *logger) Set(key string, value Valuer) Logger {
 	})
 }
 
+func (l *logger) WithPrefix(ctxs ...Context) Logger {
+	prefixes := []interface{}{}
+
+	for _, ctx := range ctxs {
+		for k, v := range ctx.Context() {
+			prefixes = append(prefixes, k, v.getValue())
+		}
+	}
+
+	return &logger{
+		writer: log.WithPrefix(l.writer, prefixes...),
+		ctx:    l.ctx,
+	}
+}
+
 // With returns a new Logger with the contexts added to its own.
 func (l *logger) With(ctxs ...Context) Logger {
 	// Estimation assuming that for each ctxs has at least 1 value.

--- a/log/logger_test.go
+++ b/log/logger_test.go
@@ -166,6 +166,72 @@ func Test_Send(t *testing.T) {
 	a.Contains(got, "foo=bar")
 }
 
+func Test_WithPrefix(t *testing.T) {
+	a, buffer, log := Setup(t)
+	log = log.WithPrefix(lib.Fields{"persist": lib.Bool(true)})
+	log.Log("prefix")
+	a.Contains(buffer.String(), "persist=true")
+
+	buffer.Reset()
+	log.With(lib.Fields{"a": lib.String("a"), "b": lib.String("b")}).Log("with")
+	a.Contains(buffer.String(), "persist=true")
+	a.Contains(buffer.String(), "a=a")
+	a.Contains(buffer.String(), "b=b")
+
+	buffer.Reset()
+	log.Log("prefix")
+	a.Contains(buffer.String(), "persist=true")
+	a.NotContains(buffer.String(), "a=a")
+	a.NotContains(buffer.String(), "b=b")
+
+	buffer.Reset()
+	log = log.WithPrefix(lib.Fields{"another": lib.String("one")})
+	log.Log("two prefix, nested")
+	a.Contains(buffer.String(), "persist=true")
+	a.Contains(buffer.String(), "another=one")
+
+	buffer.Reset()
+	log.With(lib.Fields{"a": lib.String("a"), "b": lib.String("b")}).Log("two prefix, nested, with")
+	a.Contains(buffer.String(), "persist=true")
+	a.Contains(buffer.String(), "another=one")
+	a.Contains(buffer.String(), "a=a")
+	a.Contains(buffer.String(), "b=b")
+
+	buffer.Reset()
+	log.Log("two prefix, nested")
+	a.Contains(buffer.String(), "persist=true")
+	a.Contains(buffer.String(), "another=one")
+	a.NotContains(buffer.String(), "a=a")
+	a.NotContains(buffer.String(), "b=b")
+
+	// two prefix, nested, one prefix with two fields
+	buffer.Reset()
+	log = log.WithPrefix(lib.Fields{"one": lib.String("one"), "two": lib.String("two")})
+	log.Log("two prefix, nested, one prefix with two fields")
+	a.Contains(buffer.String(), "persist=true")
+	a.Contains(buffer.String(), "another=one")
+	a.Contains(buffer.String(), "one=one")
+	a.Contains(buffer.String(), "two=two")
+
+	buffer.Reset()
+	log.With(lib.Fields{"a": lib.String("a"), "b": lib.String("b")}).Log("two prefix, nested, one prefix with two fields, with")
+	a.Contains(buffer.String(), "persist=true")
+	a.Contains(buffer.String(), "another=one")
+	a.Contains(buffer.String(), "one=one")
+	a.Contains(buffer.String(), "two=two")
+	a.Contains(buffer.String(), "a=a")
+	a.Contains(buffer.String(), "b=b")
+
+	buffer.Reset()
+	log.Log("two prefix, nested, one prefix with two fields")
+	a.Contains(buffer.String(), "persist=true")
+	a.Contains(buffer.String(), "another=one")
+	a.Contains(buffer.String(), "one=one")
+	a.Contains(buffer.String(), "two=two")
+	a.NotContains(buffer.String(), "a=a")
+	a.NotContains(buffer.String(), "b=b")
+}
+
 func Test_WithContext(t *testing.T) {
 	a, buffer, log := Setup(t)
 


### PR DESCRIPTION
# Changes

- Add interface WithPrefix
- Implement logger.WithPrefix method, which users underlying go-kit/log.WithPrefix()
- Add test for new WithPrefix

# Why

I need to set prefix values at construction of a logger, or upon entering a a function set function-relevant values in the logger which will persist after serially logging. WithPrefix allows for setting values which will always be logged when .Log() is called, until that logger is cleaned up.

# Example use

```go
func (s *service) Get(id string, requestID string) (*Widget, error) {
contextualLogger := s.logger.WithPrefix(log.Fields{"function": log.String("service.Get"), "request_id": log.String(request_id)})

contextualLogger.Debug().Log("getting widget from store")
widget, err := s.store.Get(id)
if err !=nil {
  contextualLogger.Error().Log("something bad happened")
  return nil, err
}

contextualLogger.Debug().Log("returning widget")
return widget, nil
}
```