### PR TITLE
database: Add MySQL SSL CA file config option

### DIFF
--- a/database/database.go
+++ b/database/database.go
@@ -16,7 +16,7 @@ import (
 // variables for that specific database.
 func New(ctx context.Context, logger log.Logger, config DatabaseConfig) (*sql.DB, error) {
 	if config.MySQL != nil {
-		db, err := mysqlConnection(logger, config.MySQL.User, config.MySQL.Password, config.MySQL.Address, config.DatabaseName).Connect(ctx)
+		db, err := mysqlConnection(logger, config.MySQL.User, config.MySQL.Password, config.MySQL.Address, config.DatabaseName, config.MySQL.SSLCA).Connect(ctx)
 		if err != nil {
 			return nil, err
 		}

--- a/database/model_config.go
+++ b/database/model_config.go
@@ -20,6 +20,7 @@ type MySQLConfig struct {
 	Address     string
 	User        string
 	Password    string
+	SSLCA       string
 	Connections ConnectionsConfig
 }
 

--- a/database/model_config_test.go
+++ b/database/model_config_test.go
@@ -16,6 +16,7 @@ func TestMySQLConfig(t *testing.T) {
 		Address:  "tcp(localhost:3306)",
 		User:     "app",
 		Password: "secret",
+		SSLCA:    "/etc/ssl/certs/dummy.crt",
 		Connections: ConnectionsConfig{
 			MaxOpen: 100,
 		},

--- a/database/mysql.go
+++ b/database/mysql.go
@@ -94,13 +94,25 @@ func (my *mysql) Connect(ctx context.Context) (*sql.DB, error) {
 	return db, nil
 }
 
-func mysqlConnection(logger log.Logger, user, pass string, address string, database string) *mysql {
+func mysqlConnection(logger log.Logger, user, pass string, address string, database string, sslCA string) *mysql {
 	timeout := "30s"
 	if v := os.Getenv("MYSQL_TIMEOUT"); v != "" {
 		timeout = v
 	}
-	params := fmt.Sprintf(`timeout=%s&charset=utf8mb4&parseTime=true&sql_mode="ALLOW_INVALID_DATES,STRICT_ALL_TABLES"`, timeout)
-	dsn := fmt.Sprintf("%s:%s@%s/%s?%s", user, pass, address, database, params)
+
+	var params []string
+	params = append(params, fmt.Sprintf("timeout=%s", timeout))
+	params = append(params, "charset=utf8mb4")
+	params = append(params, "parseTime=true")
+	params = append(params, `sql_mode="ALLOW_INVALID_DATES,STRICT_ALL_TABLES"`)
+
+	if sslCA != "" {
+		params = append(params, fmt.Sprintf("sslca=%s", sslCA))
+	}
+
+	renderedParams := strings.Join(params, "&")
+
+	dsn := fmt.Sprintf("%s:%s@%s/%s?%s", user, pass, address, database, renderedParams)
 	return &mysql{
 		dsn:         dsn,
 		logger:      logger,

--- a/database/mysql_test.go
+++ b/database/mysql_test.go
@@ -24,7 +24,7 @@ func TestMySQL__basic(t *testing.T) {
 	require.Equal(t, 0, db.DB.Stats().OpenConnections)
 
 	// create a phony MySQL
-	m := mysqlConnection(log.NewNopLogger(), "user", "pass", "127.0.0.1:3006", "db")
+	m := mysqlConnection(log.NewNopLogger(), "user", "pass", "127.0.0.1:3006", "db", "")
 
 	ctx, cancelFunc := context.WithCancel(context.Background())
 


### PR DESCRIPTION
I left the test as-is owing to the fact that connecting to the official MySQL Docker container via TLS [is a rather involved process](https://techsparx.com/software-development/docker/damp/mysql-ssl-connection.html) and I'm mostly just trying to get a proof-of-concept going here. 