### PR TITLE
do not ignore error when walk dir in pkger

### DIFF
--- a/database/pkger.go
+++ b/database/pkger.go
@@ -29,7 +29,7 @@ func NewPkgerSource(database string) (source.Driver, error) {
 
 	pmem.MkdirAll(MIGRATIONS_DIR, 0755)
 
-	pkger.Walk(MIGRATIONS_DIR, func(path string, info os.FileInfo, err error) error {
+	err = pkger.Walk(MIGRATIONS_DIR, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
 		}
@@ -83,6 +83,9 @@ func NewPkgerSource(database string) (source.Driver, error) {
 
 		return nil
 	})
+	if err != nil {
+		return nil, fmt.Errorf("walking the migrations directory: %w", err)
+	}
 
 	drv, err := mpkger.WithInstance(pmem, MIGRATIONS_DIR)
 	if err != nil {


### PR DESCRIPTION
What:
* handle (do not ignore) error from the function that adds migration files into `pkger`

Why:

Currently, we ignore the error when pkger walks the migration directory and the migration file name does not match the expected format.  When such happens it stops adding the rest of the files. In our case with manual migrations, we named the file in a way so [golang-migrate](https://github.com/golang-migrate/migrate) will ignore it: we just removed `.up` part. But, we didn't know that we have one more layer of file format checking :( 

P.S. we should not check file name format here and delegate it to [golang-migrate](https://github.com/golang-migrate/migrate/blob/511ae9f5b6bea5190b340243169359455281458b/source/parse.go#L21)