### PR TITLE
log: add a helper for stdout logging during verbose test runs

### DIFF
--- a/log/logger_impl.go
+++ b/log/logger_impl.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"sort"
 	"strings"
+	"testing"
 	"time"
 
 	"github.com/go-kit/log"
@@ -20,6 +21,13 @@ func NewNopLogger() Logger {
 
 func NewJSONLogger() Logger {
 	return NewLogger(log.NewJSONLogger(log.NewSyncWriter(os.Stderr)))
+}
+
+func NewTestLogger() Logger {
+	if testing.Verbose() {
+		return NewDefaultLogger()
+	}
+	return NewNopLogger()
 }
 
 func NewBufferLogger() (*strings.Builder, Logger) {


### PR DESCRIPTION
Often it's helpful to 'go test ./... -v' and get more data. This
is a handy helper method to switch between stdout and discard logging.