### PR TITLE
fix: recover from panics during logging, log those if we can

### DIFF
--- a/log/model_valuer_test.go
+++ b/log/model_valuer_test.go
@@ -1,0 +1,30 @@
+package log_test
+
+import (
+	"testing"
+
+	"github.com/moov-io/base/log"
+)
+
+type Item struct {
+	Value string
+}
+
+type Foo struct {
+	Name *Item
+}
+
+func (f Foo) Context() map[string]log.Valuer {
+	return log.Fields{
+		"name": log.String(
+			f.Name.Value,
+		),
+	}
+}
+
+func TestValuer__String(t *testing.T) {
+	logger := log.NewTestLogger()
+
+	foo := Foo{}
+	logger.With(foo).Log("shouldn't panic")
+}


### PR DESCRIPTION
We've been seeing panics within our logging framework when `Context()` calls panic. Let's avoid these and record when they occur. 

```
=== RUN   TestValuer__String
level=error file=/Users/adam/code/src/github.com/moov-io/base/log/model_valuer_test.go line=20 msg="recovered from runtime.errorString - runtime error: invalid memory address or nil pointer dereference"
ts=2022-06-15T20:59:32Z msg="shouldn't panic" level=info
--- PASS: TestValuer__String (0.00s)
```