### PR TITLE
config: overwrite slices instead of merging

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -88,7 +88,6 @@ func LoadEnvironmentFile(logger log.Logger, envVar string, config interface{}) e
 }
 
 func initDecoderConfig(cfg *mapstructure.DecoderConfig) {
-	cfg.ErrorUnset = true
 	cfg.ErrorUnused = true
 	cfg.ZeroFields = true
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -41,9 +41,9 @@ func Test_Load(t *testing.T) {
 	require.Equal(t, "keep secret!", cfg.Config.Secret)
 
 	// This test documents some unexpected behavior where slices are merged and not overwritten.
-	require.Len(t, cfg.Config.Values, 2)
+	// Slices in secrets should overwrite the slice in app and default.
+	require.Len(t, cfg.Config.Values, 1)
 	require.Equal(t, "secret", cfg.Config.Values[0])
-	require.Equal(t, "test2", cfg.Config.Values[1])
 
 	require.Equal(t, "", cfg.Config.Zero)
 


### PR DESCRIPTION
 Previously it was causing issues with merging arrays where if the new array being merged wasn't bigger than the old one values would stick around. This hopefully fixes that