### PR TITLE
add similar unique violation check as sql for spanner

### DIFF
--- a/database/spanner.go
+++ b/database/spanner.go
@@ -2,14 +2,11 @@ package database
 
 import (
 	"database/sql"
-	"errors"
 	"fmt"
-	"strings"
 
 	"cloud.google.com/go/spanner"
 	"github.com/golang-migrate/migrate/v4/database"
 	migspanner "github.com/golang-migrate/migrate/v4/database/spanner"
-	"github.com/googleapis/gax-go/v2/apierror"
 	_ "github.com/googleapis/go-sql-spanner"
 	"google.golang.org/grpc/codes"
 
@@ -35,11 +32,5 @@ func SpannerMigrationDriver(cfg SpannerConfig, databaseName string) (database.Dr
 // Refer to https://cloud.google.com/spanner/docs/error-codes for Spanner error definitions,
 // and https://github.com/googleapis/googleapis/blob/master/google/rpc/code.proto for error codes
 func SpannerUniqueViolation(err error) bool {
-	match := strings.Contains(err.Error(), "Failed to insert row with primary key")
-
-	var apiErr *apierror.APIError
-	if errors.As(err, &apiErr) {
-		return match || spanner.ErrCode(apiErr) == codes.AlreadyExists
-	}
-	return match
+	return spanner.ErrCode(err) == codes.AlreadyExists
 }

--- a/database/spanner.go
+++ b/database/spanner.go
@@ -3,6 +3,7 @@ package database
 import (
 	"database/sql"
 	"fmt"
+	"strings"
 
 	"cloud.google.com/go/spanner"
 	"github.com/golang-migrate/migrate/v4/database"
@@ -32,5 +33,6 @@ func SpannerMigrationDriver(cfg SpannerConfig, databaseName string) (database.Dr
 // Refer to https://cloud.google.com/spanner/docs/error-codes for Spanner error definitions,
 // and https://github.com/googleapis/googleapis/blob/master/google/rpc/code.proto for error codes
 func SpannerUniqueViolation(err error) bool {
-	return spanner.ErrCode(err) == codes.AlreadyExists
+	match := strings.Contains(err.Error(), "Failed to insert row with primary key")
+	return match || spanner.ErrCode(err) == codes.AlreadyExists
 }

--- a/database/spanner.go
+++ b/database/spanner.go
@@ -2,13 +2,18 @@ package database
 
 import (
 	"database/sql"
+	"errors"
 	"fmt"
+	"strings"
 
-	"github.com/moov-io/base/log"
-
+	"cloud.google.com/go/spanner"
 	"github.com/golang-migrate/migrate/v4/database"
 	migspanner "github.com/golang-migrate/migrate/v4/database/spanner"
+	"github.com/googleapis/gax-go/v2/apierror"
 	_ "github.com/googleapis/go-sql-spanner"
+	"google.golang.org/grpc/codes"
+
+	"github.com/moov-io/base/log"
 )
 
 func spannerConnection(logger log.Logger, cfg SpannerConfig, databaseName string) (*sql.DB, error) {
@@ -23,4 +28,18 @@ func spannerConnection(logger log.Logger, cfg SpannerConfig, databaseName string
 func SpannerMigrationDriver(cfg SpannerConfig, databaseName string) (database.Driver, error) {
 	s := migspanner.Spanner{}
 	return s.Open(fmt.Sprintf("spanner://projects/%s/instances/%s/databases/%s?x-migrations-table=spanner_schema_migrations&x-clean-statements=true", cfg.Project, cfg.Instance, databaseName))
+}
+
+// SpannerUniqueViolation returns true when the provided error matches the Spanner code
+// for duplicate entries (violating a unique table constraint).
+// Refer to https://cloud.google.com/spanner/docs/error-codes for Spanner error definitions,
+// and https://github.com/googleapis/googleapis/blob/master/google/rpc/code.proto for error codes
+func SpannerUniqueViolation(err error) bool {
+	match := strings.Contains(err.Error(), "Failed to insert row with primary key")
+
+	var apiErr *apierror.APIError
+	if errors.As(err, &apiErr) {
+		return match || spanner.ErrCode(apiErr) == codes.AlreadyExists
+	}
+	return match
 }

--- a/database/spanner.go
+++ b/database/spanner.go
@@ -33,6 +33,6 @@ func SpannerMigrationDriver(cfg SpannerConfig, databaseName string) (database.Dr
 // Refer to https://cloud.google.com/spanner/docs/error-codes for Spanner error definitions,
 // and https://github.com/googleapis/googleapis/blob/master/google/rpc/code.proto for error codes
 func SpannerUniqueViolation(err error) bool {
-	match := strings.Contains(err.Error(), "Failed to insert row with primary key")
-	return match || spanner.ErrCode(err) == codes.AlreadyExists
+	return spanner.ErrCode(err) == codes.AlreadyExists ||
+		strings.Contains(err.Error(), "AlreadyExists")
 }

--- a/database/spanner_test.go
+++ b/database/spanner_test.go
@@ -2,6 +2,7 @@ package database_test
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"cloud.google.com/go/spanner"
@@ -78,15 +79,22 @@ func Test_MigrateAndRun(t *testing.T) {
 func TestSpannerUniqueViolation(t *testing.T) {
 	errMsg := "Failed to insert row with primary key ({pk#primary_key:\"282f6ffcd9ba5b029afbf2b739ee826e22d9df3b\"}) due to previously existing row"
 	// Test backwards-compatible parsing of spanner.Error (soon to be deprecated) from Spanner client
-	oldSpannerErr := spanner.ToSpannerError(status.New(codes.AlreadyExists, errMsg).Err())
+	statusErr := status.New(codes.AlreadyExists, errMsg).Err()
+	oldSpannerErr := spanner.ToSpannerError(statusErr)
 	if !database.SpannerUniqueViolation(oldSpannerErr) {
 		t.Error("should have matched unique violation")
 	}
 
 	// Test new apirerror.APIError response from Spanner client
-	newSpannerErr, parseErr := apierror.FromError(status.New(codes.AlreadyExists, errMsg).Err())
+	newSpannerErr, parseErr := apierror.FromError(statusErr)
 	require.True(t, parseErr)
 	if !database.SpannerUniqueViolation(newSpannerErr) {
+		t.Error("should have matched unique violation")
+	}
+
+	// Test wrapped spanner error
+	wrappedErr := fmt.Errorf("wrapped err: %w", statusErr)
+	if !database.SpannerUniqueViolation(wrappedErr) {
 		t.Error("should have matched unique violation")
 	}
 }

--- a/database/spanner_test.go
+++ b/database/spanner_test.go
@@ -4,10 +4,15 @@ import (
 	"context"
 	"testing"
 
+	"cloud.google.com/go/spanner"
+	"github.com/googleapis/gax-go/v2/apierror"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
 	"github.com/moov-io/base/database"
 	"github.com/moov-io/base/database/testdb"
 	"github.com/moov-io/base/log"
-	"github.com/stretchr/testify/require"
 )
 
 func Test_OpenConnection(t *testing.T) {
@@ -68,4 +73,20 @@ func Test_MigrateAndRun(t *testing.T) {
 	require.NoError(t, err)
 	defer rows.Close()
 	require.NoError(t, rows.Err())
+}
+
+func TestSpannerUniqueViolation(t *testing.T) {
+	errMsg := "Failed to insert row with primary key ({pk#primary_key:\"282f6ffcd9ba5b029afbf2b739ee826e22d9df3b\"}) due to previously existing row"
+	// Test backwards-compatible parsing of spanner.Error (soon to be deprecated) from Spanner client
+	oldSpannerErr := spanner.ToSpannerError(status.New(codes.AlreadyExists, errMsg).Err())
+	if !database.SpannerUniqueViolation(oldSpannerErr) {
+		t.Error("should have matched unique violation")
+	}
+
+	// Test new apirerror.APIError response from Spanner client
+	newSpannerErr, parseErr := apierror.FromError(status.New(codes.AlreadyExists, errMsg).Err())
+	require.True(t, parseErr)
+	if !database.SpannerUniqueViolation(newSpannerErr) {
+		t.Error("should have matched unique violation")
+	}
 }


### PR DESCRIPTION
Changes:
* Similar to what we support for `mysql::MySQLUniqueViolation`, added `spanner::SpannerUniqueViolation` that look at the error code or message to deduce if we have a duplicate error. 

Note: `spanner.Error` will be deprecated in the future, replaced with `APIError`. I added tests for both responses from client.
 
![Screenshot 2023-05-01 at 4 21 25 PM](https://user-images.githubusercontent.com/28032700/235524216-87e1822c-7b7e-4104-99f0-6830a8794169.png)
