### PR TITLE
Go:Embed

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/moov-io/base"
 	"github.com/moov-io/base/config"
 	"github.com/moov-io/base/log"
 	"github.com/stretchr/testify/require"
@@ -34,6 +35,45 @@ func Test_Load(t *testing.T) {
 
 	service := config.NewService(log.NewDefaultLogger())
 	err := service.Load(cfg)
+	require.Nil(t, err)
+
+	require.Equal(t, "default", cfg.Config.Default)
+	require.Equal(t, "app", cfg.Config.App)
+	require.Equal(t, "keep secret!", cfg.Config.Secret)
+
+	// This test documents some unexpected behavior where slices are merged and not overwritten.
+	// Slices in secrets should overwrite the slice in app and default.
+	require.Len(t, cfg.Config.Values, 1)
+	require.Equal(t, "secret", cfg.Config.Values[0])
+
+	require.Equal(t, "", cfg.Config.Zero)
+
+	// Verify attempting to load from our default file errors on extra fields
+	cfg = &GlobalConfigModel{}
+	err = service.LoadFile("/configs/config.extra.yml", &cfg)
+	require.NotNil(t, err)
+	require.Contains(t, err.Error(), `'Config' has invalid keys: extra`)
+
+	// Verify attempting to load additional fields via env vars errors out
+	os.Setenv(config.APP_CONFIG, filepath.Join("..", "configs", "config.extra.yml"))
+	cfg = &GlobalConfigModel{}
+	err = service.Load(cfg)
+	require.NotNil(t, err)
+	require.Contains(t, err.Error(), `'Config' has invalid keys: extra`)
+}
+
+func Test_Embedded_Load(t *testing.T) {
+	os.Setenv(config.APP_CONFIG, filepath.Join("..", "configs", "config.app.yml"))
+	os.Setenv(config.APP_CONFIG_SECRETS, filepath.Join("..", "configs", "config.secrets.yml"))
+	t.Cleanup(func() {
+		os.Unsetenv(config.APP_CONFIG)
+		os.Unsetenv(config.APP_CONFIG_SECRETS)
+	})
+
+	cfg := &GlobalConfigModel{}
+
+	service := config.NewService(log.NewDefaultLogger())
+	err := service.LoadFromFS(cfg, base.ConfigDefaults)
 	require.Nil(t, err)
 
 	require.Equal(t, "default", cfg.Config.Default)

--- a/database/database.go
+++ b/database/database.go
@@ -35,7 +35,7 @@ func New(ctx context.Context, logger log.Logger, config DatabaseConfig) (*sql.DB
 	return nil, fmt.Errorf("database config not defined")
 }
 
-func NewAndMigrate(ctx context.Context, logger log.Logger, config DatabaseConfig) (*sql.DB, error) {
+func NewAndMigrate(ctx context.Context, logger log.Logger, config DatabaseConfig, opts ...MigrateOption) (*sql.DB, error) {
 	if logger == nil {
 		logger = log.NewNopLogger()
 	}
@@ -45,7 +45,7 @@ func NewAndMigrate(ctx context.Context, logger log.Logger, config DatabaseConfig
 	}
 
 	// run migrations first
-	if err := RunMigrations(logger, config); err != nil {
+	if err := RunMigrations(logger, config, opts...); err != nil {
 		return nil, err
 	}
 

--- a/database/database_test.go
+++ b/database/database_test.go
@@ -1,16 +1,18 @@
 // Copyright 2020 The Moov Authors
 // Use of this source code is governed by an Apache License
 // license that can be found in the LICENSE file.
-package database
+package database_test
 
 import (
 	"errors"
 	"testing"
+
+	"github.com/moov-io/base/database"
 )
 
 func TestUniqueViolation(t *testing.T) {
 	err := errors.New(`problem upserting depository="282f6ffcd9ba5b029afbf2b739ee826e22d9df3b", userId="f25f48968da47ef1adb5b6531a1c2197295678ce": Error 1062: Duplicate entry '282f6ffcd9ba5b029afbf2b739ee826e22d9df3b' for key 'PRIMARY'`)
-	if !UniqueViolation(err) {
+	if !database.UniqueViolation(err) {
 		t.Error("should have matched unique violation")
 	}
 }

--- a/database/model_config_test.go
+++ b/database/model_config_test.go
@@ -1,22 +1,23 @@
 // Copyright 2020 The Moov Authors
 // Use of this source code is governed by an Apache License
 // license that can be found in the LICENSE file.
-package database
+package database_test
 
 import (
 	"bytes"
 	"encoding/json"
 	"testing"
 
+	"github.com/moov-io/base/database"
 	"github.com/stretchr/testify/require"
 )
 
 func TestMySQLConfig(t *testing.T) {
-	cfg := &MySQLConfig{
+	cfg := &database.MySQLConfig{
 		Address:  "tcp(localhost:3306)",
 		User:     "app",
 		Password: "secret",
-		Connections: ConnectionsConfig{
+		Connections: database.ConnectionsConfig{
 			MaxOpen: 100,
 		},
 	}

--- a/database/mysql.go
+++ b/database/mysql.go
@@ -101,9 +101,9 @@ func (my *mysql) Connect(ctx context.Context) (*sql.DB, error) {
 	db.SetMaxOpenConns(maxActiveMySQLConnections)
 
 	// Check out DB is up and working
-	// if err := db.Ping(); err != nil {
-	// 	return nil, err
-	// }
+	if err := db.Ping(); err != nil {
+		return nil, err
+	}
 
 	// Setup metrics after the database is setup
 	go func(db *sql.DB) {

--- a/database/mysql.go
+++ b/database/mysql.go
@@ -101,9 +101,9 @@ func (my *mysql) Connect(ctx context.Context) (*sql.DB, error) {
 	db.SetMaxOpenConns(maxActiveMySQLConnections)
 
 	// Check out DB is up and working
-	if err := db.Ping(); err != nil {
-		return nil, err
-	}
+	// if err := db.Ping(); err != nil {
+	// 	return nil, err
+	// }
 
 	// Setup metrics after the database is setup
 	go func(db *sql.DB) {

--- a/database/mysql_test.go
+++ b/database/mysql_test.go
@@ -1,14 +1,18 @@
 // Copyright 2020 The Moov Authors
 // Use of this source code is governed by an Apache License
 // license that can be found in the LICENSE file.
-package database
+package database_test
 
 import (
 	"context"
 	"database/sql"
 	"errors"
 	"testing"
+	"time"
 
+	"github.com/moov-io/base"
+	"github.com/moov-io/base/database"
+	"github.com/moov-io/base/database/testdb"
 	"github.com/moov-io/base/log"
 	"github.com/stretchr/testify/require"
 )
@@ -19,60 +23,57 @@ func TestMySQL__basic(t *testing.T) {
 	}
 
 	// create a phony MySQL
-	mysqlConfig := &MySQLConfig{
-		User:     "moov",
-		Password: "moov",
-		Address:  "tcp(127.0.0.1:3306)",
+	mysqlConfig := database.DatabaseConfig{
+		DatabaseName: "moov",
+		MySQL: &database.MySQLConfig{
+			User:     "moov",
+			Password: "moov",
+			Address:  "tcp(127.0.0.1:3306)",
+		},
 	}
-	m, err := mysqlConnection(log.NewNopLogger(), mysqlConfig, "moov")
-	require.NoError(t, err)
 
 	ctx, cancelFunc := context.WithCancel(context.Background())
+	defer cancelFunc()
 
-	conn, err := m.Connect(ctx)
-	defer func() {
-		if conn != nil {
-			conn.Close()
-		}
-	}()
-	require.NotNil(t, conn)
+	m, err := database.New(ctx, log.NewNopLogger(), mysqlConfig)
 	require.NoError(t, err)
+	defer m.Close()
+
+	require.NotNil(t, m)
 
 	// Inspect the global and session SQL modes
 	// See: https://dev.mysql.com/doc/refman/8.0/en/sql-mode.html#sql-mode-setting
-	sqlModes := readSQLModes(t, conn, "SELECT @@SESSION.sql_mode;")
+	sqlModes := readSQLModes(t, m, "SELECT @@SESSION.sql_mode;")
 	require.Contains(t, sqlModes, "ALLOW_INVALID_DATES")
 	require.Contains(t, sqlModes, "STRICT_ALL_TABLES")
 
-	require.Equal(t, 1, conn.Stats().OpenConnections)
-
-	cancelFunc()
+	require.Equal(t, 1, m.Stats().OpenConnections)
 }
 
 func TestMySQLUniqueViolation(t *testing.T) {
 	err := errors.New(`problem upserting depository="282f6ffcd9ba5b029afbf2b739ee826e22d9df3b", userId="f25f48968da47ef1adb5b6531a1c2197295678ce": Error 1062: Duplicate entry '282f6ffcd9ba5b029afbf2b739ee826e22d9df3b' for key 'PRIMARY'`)
-	if !UniqueViolation(err) {
+	if !database.UniqueViolation(err) {
 		t.Error("should have matched unique violation")
 	}
 }
 
 func TestMySQLUniqueViolation_WithStateValue(t *testing.T) {
 	err := errors.New(`problem upserting depository="282f6ffcd9ba5b029afbf2b739ee826e22d9df3b", userId="f25f48968da47ef1adb5b6531a1c2197295678ce": Error 1062 (23000): Duplicate entry '282f6ffcd9ba5b029afbf2b739ee826e22d9df3b' for key 'PRIMARY'`)
-	if !UniqueViolation(err) {
+	if !database.UniqueViolation(err) {
 		t.Error("should have matched unique violation")
 	}
 }
 
 func TestMySQLDataTooLong(t *testing.T) {
 	err := errors.New("Error 1406: Data too long")
-	if !MySQLDataTooLong(err) {
+	if !database.MySQLDataTooLong(err) {
 		t.Error("should have matched")
 	}
 }
 
 func TestMySQLDataTooLong_WithStateValue(t *testing.T) {
 	err := errors.New("Error 1406 (22001): Data too long")
-	if !MySQLDataTooLong(err) {
+	if !database.MySQLDataTooLong(err) {
 		t.Error("should have matched")
 	}
 }
@@ -88,4 +89,33 @@ func readSQLModes(t *testing.T, db *sql.DB, query string) string {
 	var sqlModes string
 	require.NoError(t, row.Scan(&sqlModes))
 	return sqlModes
+}
+
+func Test_MySQL_Embedded_Migration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("-short flag enabled")
+	}
+
+	// create a phony MySQL
+	mysqlConfig := database.DatabaseConfig{
+		DatabaseName: "moov2" + base.ID(),
+		MySQL: &database.MySQLConfig{
+			User:     "root",
+			Password: "root",
+			Address:  "tcp(127.0.0.1:3306)",
+			Connections: database.ConnectionsConfig{
+				MaxOpen:     1,
+				MaxIdle:     1,
+				MaxLifetime: time.Minute,
+				MaxIdleTime: time.Second,
+			},
+		},
+	}
+
+	err := testdb.NewMySQLDatabase(t, mysqlConfig)
+	require.NoError(t, err)
+
+	db, err := database.NewAndMigrate(context.Background(), log.NewDefaultLogger(), mysqlConfig, database.WithEmbeddedMigrations(base.MySQLMigrations))
+	require.NoError(t, err)
+	defer db.Close()
 }

--- a/database/spanner_test.go
+++ b/database/spanner_test.go
@@ -11,6 +11,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
+	"github.com/moov-io/base"
 	"github.com/moov-io/base/database"
 	"github.com/moov-io/base/database/testdb"
 	"github.com/moov-io/base/log"
@@ -97,6 +98,22 @@ func Test_MigrateAndRun(t *testing.T) {
 	require.NoError(t, err)
 	defer rows.Close()
 	require.NoError(t, rows.Err())
+}
+
+func Test_Embedded_Migration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("-short flag enabled")
+	}
+
+	// Switches the spanner driver into using the emulator and bypassing the auth checks.
+	testdb.SetSpannerEmulator(nil)
+
+	cfg, err := testdb.NewSpannerDatabase("mydb", nil)
+	require.NoError(t, err)
+
+	db, err := database.NewAndMigrate(context.Background(), log.NewDefaultLogger(), cfg, database.WithEmbeddedMigrations(base.SpannerMigrations))
+	require.NoError(t, err)
+	defer db.Close()
 }
 
 func TestSpannerUniqueViolation(t *testing.T) {

--- a/database/testdb/mysql.go
+++ b/database/testdb/mysql.go
@@ -1,0 +1,37 @@
+package testdb
+
+import (
+	"database/sql"
+	"fmt"
+	"testing"
+
+	"github.com/moov-io/base/database"
+)
+
+func NewMySQLDatabase(t *testing.T, cfg database.DatabaseConfig) error {
+	t.Helper()
+	if cfg.MySQL == nil {
+		return fmt.Errorf("mysql config not defined")
+	}
+
+	rootDb, err := sql.Open("mysql", fmt.Sprintf("%s:%s@%s/", cfg.MySQL.User, cfg.MySQL.Password, cfg.MySQL.Address))
+	if err != nil {
+		return err
+	}
+
+	if err := rootDb.Ping(); err != nil {
+		return err
+	}
+
+	_, err = rootDb.Exec(fmt.Sprintf("CREATE DATABASE %s", cfg.DatabaseName))
+	if err != nil {
+		return err
+	}
+
+	t.Cleanup(func() {
+		rootDb.Exec(fmt.Sprintf("DROP DATABASE %s", cfg.DatabaseName))
+		rootDb.Close()
+	})
+
+	return nil
+}

--- a/package.go
+++ b/package.go
@@ -1,0 +1,6 @@
+package base
+
+import "embed"
+
+//go:embed configs/config.default.yml
+var ConfigDefaults embed.FS

--- a/package.go
+++ b/package.go
@@ -4,3 +4,9 @@ import "embed"
 
 //go:embed configs/config.default.yml
 var ConfigDefaults embed.FS
+
+//go:embed migrations/*.up.sql migrations/*.up.mysql.sql
+var MySQLMigrations embed.FS
+
+//go:embed migrations/*.up.spanner.sql
+var SpannerMigrations embed.FS


### PR DESCRIPTION
Adds in support for go:embedding without breaking compatibility for pkger which is still used as the default for both migrations and default config files.

With adding it it adds in the options/curried functions pattern to be able to add configuration later, like the timeout one I added.