### PR TITLE
add orderBy param

### DIFF
--- a/http/server.go
+++ b/http/server.go
@@ -165,7 +165,7 @@ func readSkipCount(r *http.Request, skipMax, countMax int) (skip int, count int,
 // - sortBy is the name of the field to sort by
 // - order is the direction for sortBy (ascending or descending)
 func GetSortByAndOrder(r *http.Request) (sortBy string, order string) {
-	sortBy = r.URL.Query().Get("sort-by")
+	sortBy = r.URL.Query().Get("sortBy")
 	order = r.URL.Query().Get("order")
 	return sortBy, order
 }

--- a/http/server.go
+++ b/http/server.go
@@ -6,6 +6,7 @@ package http
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"math"
 	"net/http"
@@ -161,11 +162,57 @@ func readSkipCount(r *http.Request, skipMax, countMax int) (skip int, count int,
 	return skip, count, exists, nil
 }
 
-// GetSortByAndOrder returns the sortBy and order values from the query parameters
-// - sortBy is the name of the field to sort by
-// - order is the direction for sortBy (ascending or descending)
-func GetSortByAndOrder(r *http.Request) (sortBy string, order string) {
-	sortBy = r.URL.Query().Get("sortBy")
-	order = r.URL.Query().Get("order")
-	return sortBy, order
+type Direction string
+
+const (
+	Ascending  Direction = "ASC"
+	Descending Direction = "DESC"
+)
+
+type OrderBy struct {
+	Name      string
+	Direction Direction
+}
+
+// GetOrderBy returns the field names and direction to order the response by
+func GetOrderBy(r *http.Request) ([]OrderBy, error) {
+	orderByParam := r.URL.Query().Get("orderBy")
+	if orderByParam == "" {
+		return []OrderBy{}, nil
+	}
+
+	paramSplit := strings.Split(orderByParam, ",")
+	var orderBys []OrderBy
+	for _, split := range paramSplit {
+		orderBy := strings.Split(split, ":")
+		if len(orderBy) != 2 {
+			return nil, fmt.Errorf("invalid orderBy: %s", orderBy)
+		}
+
+		name := strings.TrimSpace(orderBy[0])
+		if name == "" {
+			return nil, errors.New("missing orderBy name")
+		}
+
+		directionStr := strings.TrimSpace(orderBy[1])
+		if directionStr == "" {
+			return nil, errors.New("missing orderBy direction")
+		}
+		directionStr = strings.ToLower(directionStr)
+
+		var direction Direction
+		if strings.HasPrefix(directionStr, "asc") {
+			direction = Ascending
+		} else if strings.HasPrefix(directionStr, "desc") {
+			direction = Descending
+		} else {
+			return nil, fmt.Errorf("invalid orderBy direction: %s", direction)
+		}
+
+		orderBys = append(orderBys, OrderBy{
+			Name:      name,
+			Direction: direction,
+		})
+	}
+	return orderBys, nil
 }

--- a/http/server.go
+++ b/http/server.go
@@ -160,3 +160,14 @@ func readSkipCount(r *http.Request, skipMax, countMax int) (skip int, count int,
 
 	return skip, count, exists, nil
 }
+
+// GetSortByAndOrder returns the sortBy and order values from the query parameters
+// - sortBy is the name of the field to sort by
+// - order is the direction for sortBy (ascending or descending)
+// - exists indicates if sortBy or order was passed into the request URL
+func GetSortByAndOrder(r *http.Request) (sortBy string, order string, exists bool) {
+	sortBy = r.URL.Query().Get("sortBy")
+	order = r.URL.Query().Get("order")
+	exists = len(sortBy) > 0 || len(order) > 0
+	return sortBy, order, exists
+}

--- a/http/server.go
+++ b/http/server.go
@@ -164,10 +164,8 @@ func readSkipCount(r *http.Request, skipMax, countMax int) (skip int, count int,
 // GetSortByAndOrder returns the sortBy and order values from the query parameters
 // - sortBy is the name of the field to sort by
 // - order is the direction for sortBy (ascending or descending)
-// - exists indicates if sortBy or order was passed into the request URL
-func GetSortByAndOrder(r *http.Request) (sortBy string, order string, exists bool) {
-	sortBy = r.URL.Query().Get("sortBy")
+func GetSortByAndOrder(r *http.Request) (sortBy string, order string) {
+	sortBy = r.URL.Query().Get("sort-by")
 	order = r.URL.Query().Get("order")
-	exists = len(sortBy) > 0 || len(order) > 0
-	return sortBy, order, exists
+	return sortBy, order
 }

--- a/http/server_test.go
+++ b/http/server_test.go
@@ -339,7 +339,7 @@ func TestLimitedSkipCount(t *testing.T) {
 }
 
 func TestGetSortByAndOrder(t *testing.T) {
-	r := httptest.NewRequest("GET", "/list?sort-by=created-on&order=ascending", nil)
+	r := httptest.NewRequest("GET", "/list?sortBy=created-on&order=ascending", nil)
 	sortBy, order := GetSortByAndOrder(r)
 	require.Equal(t, "created-on", sortBy)
 	require.Equal(t, "ascending", order)

--- a/http/server_test.go
+++ b/http/server_test.go
@@ -337,3 +337,11 @@ func TestLimitedSkipCount(t *testing.T) {
 	require.Equal(t, 250, skip)
 	require.Equal(t, 100, count)
 }
+
+func TestGetSortByAndOrder(t *testing.T) {
+	r := httptest.NewRequest("GET", "/list?sortBy=createdOn&order=ascending", nil)
+	sortBy, order, exists := GetSortByAndOrder(r)
+	require.Equal(t, "createdOn", sortBy)
+	require.Equal(t, "ascending", order)
+	require.True(t, exists)
+}

--- a/http/server_test.go
+++ b/http/server_test.go
@@ -339,9 +339,8 @@ func TestLimitedSkipCount(t *testing.T) {
 }
 
 func TestGetSortByAndOrder(t *testing.T) {
-	r := httptest.NewRequest("GET", "/list?sortBy=createdOn&order=ascending", nil)
-	sortBy, order, exists := GetSortByAndOrder(r)
-	require.Equal(t, "createdOn", sortBy)
+	r := httptest.NewRequest("GET", "/list?sort-by=created-on&order=ascending", nil)
+	sortBy, order := GetSortByAndOrder(r)
+	require.Equal(t, "created-on", sortBy)
 	require.Equal(t, "ascending", order)
-	require.True(t, exists)
 }


### PR DESCRIPTION
adding the `orderBy` param that way it's reusable and consistent if/when we add new endpoints that use ordering. this is [similar to how we handle paging](https://github.com/moov-io/base/blob/master/http/server.go#L122).