### PR TITLE
Check nil on fmt stringer

### DIFF
--- a/log/model_valuer.go
+++ b/log/model_valuer.go
@@ -93,6 +93,9 @@ func ByteBase64(b []byte) Valuer {
 }
 
 func Stringer(s fmt.Stringer) Valuer {
+	if s == nil {
+		return &any{nil}
+	}
 	return &any{s.String()}
 }
 

--- a/log/model_valuer.go
+++ b/log/model_valuer.go
@@ -94,7 +94,7 @@ func ByteBase64(b []byte) Valuer {
 }
 
 func Stringer(s fmt.Stringer) Valuer {
-	if reflect.ValueOf(s).Kind() == reflect.Pointer && reflect.ValueOf(s).IsNil() {
+	if v := reflect.ValueOf(s); v.Kind() == reflect.Pointer && v.IsNil() {
 		return &any{nil}
 	}
 

--- a/log/model_valuer.go
+++ b/log/model_valuer.go
@@ -3,6 +3,7 @@ package log
 import (
 	"encoding/base64"
 	"fmt"
+	"reflect"
 	"strings"
 	"time"
 )
@@ -93,9 +94,10 @@ func ByteBase64(b []byte) Valuer {
 }
 
 func Stringer(s fmt.Stringer) Valuer {
-	if s == nil {
+	if reflect.ValueOf(s).Kind() == reflect.Pointer && reflect.ValueOf(s).IsNil() {
 		return &any{nil}
 	}
+
 	return &any{s.String()}
 }
 

--- a/log/model_valuer_test.go
+++ b/log/model_valuer_test.go
@@ -52,4 +52,14 @@ func TestValuer_Stringer(t *testing.T) {
 	}).Log("log with .String() key/value pair")
 
 	require.Contains(t, out.String(), `mode=PRODUCTION`)
+
+	out, logger = log.NewBufferLogger()
+
+	var n *Mode
+
+	logger.With(log.Fields{
+		"mode": log.Stringer(n),
+	}).Log("log with nil .String() key/value pair")
+
+	require.Contains(t, out.String(), `mode=null`)
 }


### PR DESCRIPTION
- Prevent panic when calling `log.Stringer(nil)`