### PR TITLE
log: set level=error for .LogError and .LogErrorf

### DIFF
--- a/log/logger_impl.go
+++ b/log/logger_impl.go
@@ -38,6 +38,8 @@ func NewJSONLogger() Logger {
 	return NewLogger(log.NewJSONLogger(log.NewSyncWriter(os.Stderr)))
 }
 
+// NewTestLogger returns a default logger if the testing verbose (-v) flag is set
+// otherwise a no-op logger is returned.
 func NewTestLogger() Logger {
 	if testing.Verbose() {
 		return NewDefaultLogger()
@@ -220,8 +222,9 @@ func (l *logger) Send() {
 	l.Log("")
 }
 
+// LogError logs the error at level=error and returns the logged error.
 func (l *logger) LogError(err error) LoggedError {
-	l.Set("errored", Bool(true)).Log(err.Error())
+	l.Set("errored", Bool(true)).Error().Log(err.Error())
 	return LoggedError{err}
 }
 

--- a/log/logger_test.go
+++ b/log/logger_test.go
@@ -323,3 +323,19 @@ func Setup(t *testing.T) (*assert.Assertions, *lib.BufferedLogger, lib.Logger) {
 	buffer, log := lib.NewBufferLogger()
 	return a, buffer, log
 }
+
+func Test_Log_LogError(t *testing.T) {
+	a, buffer, log := Setup(t)
+
+	log2 := log.LogError(errors.New("bad thing"))
+	a.Equal("bad thing", log2.Err().Error())
+
+	details := log.Details()
+	level, ok := details["level"].(string)
+	a.True(ok)
+	a.Equal("info", level)
+
+	output := buffer.String()
+	a.Contains(output, `msg="bad thing"`)
+	a.Contains(output, `level=error`)
+}


### PR DESCRIPTION
Previously you could get logs at info/debug/etc levels with `errored=true` that aren't `level=error`. 