### PR TITLE
Don't print Go type in ParseError messages

### DIFF
--- a/error.go
+++ b/error.go
@@ -30,9 +30,9 @@ type ParseError struct {
 
 func (e ParseError) Error() string {
 	if e.Record == "" {
-		return fmt.Sprintf("line:%d %T %s", e.Line, e.Err, e.Err)
+		return fmt.Sprintf("line:%d %s", e.Line, e.Err)
 	}
-	return fmt.Sprintf("line:%d record:%s %T %s", e.Line, e.Record, e.Err, e.Err)
+	return fmt.Sprintf("line:%d record:%s %s", e.Line, e.Record, e.Err)
 }
 
 // Unwrap implements the UnwrappableError interface for ParseError

--- a/error.go
+++ b/error.go
@@ -26,13 +26,21 @@ type ParseError struct {
 	Line   int    // Line number where the error occurred
 	Record string // Name of the record type being parsed
 	Err    error  // The actual error
+	SuppressType bool // Whether to exclude the Go error type from string representation
 }
 
 func (e ParseError) Error() string {
-	if e.Record == "" {
-		return fmt.Sprintf("line:%d %s", e.Line, e.Err)
+	if e.SuppressType {
+		if e.Record == "" {
+			return fmt.Sprintf("line:%d %s", e.Line, e.Err)
+		}
+		return fmt.Sprintf("line:%d record:%s %s", e.Line, e.Record, e.Err)
+	} else {
+		if e.Record == "" {
+			return fmt.Sprintf("line:%d %T %s", e.Line, e.Err, e.Err)
+		}
+		return fmt.Sprintf("line:%d record:%s %T %s", e.Line, e.Record, e.Err, e.Err)
 	}
-	return fmt.Sprintf("line:%d record:%s %s", e.Line, e.Record, e.Err)
 }
 
 // Unwrap implements the UnwrappableError interface for ParseError

--- a/error_test.go
+++ b/error_test.go
@@ -50,7 +50,7 @@ func TestParseErrorRecordNull_Error(t *testing.T) {
 
 	e1 := pse.Error()
 
-	if e1 != "line:5 base.ErrorList testing" {
+	if e1 != "line:5 testing" {
 		t.Errorf("got %s", e1)
 	}
 }


### PR DESCRIPTION
`ParseError`s currently print the internal Go type of the wrapped `error` when formatted as strings. In practice this seems to be superfluous and clutters the error messages with information primarily of interest to `moov-io` developers. The wrapped `error` already aptly describes why parsing failed.

Since no other Moov errors display Go types when formatted, this PR removes the Go type from the string representation of `ParseError`s.