### PR TITLE
Support `google/alloydbmoni` for local dev

### DIFF
--- a/database/model_config.go
+++ b/database/model_config.go
@@ -31,6 +31,7 @@ type PostgresConfig struct {
 	Connections ConnectionsConfig
 	TLS         *PostgresTLSConfig
 	Alloy       *PostgresAlloyConfig
+	DisableSSL  bool
 }
 
 type PostgresTLSConfig struct {

--- a/database/postgres.go
+++ b/database/postgres.go
@@ -72,6 +72,10 @@ func getPostgresConnStr(config PostgresConfig, databaseName string) (string, err
 		if config.TLS.ClientKeyFile != "" {
 			params += "&sslkey=" + config.TLS.ClientKeyFile
 		}
+	} else if config.DisableSSL {
+		// When using google/alloydbomni for local development, it will establish a postgres connection
+		// with SSL enabled by default, so we need to disable it to successfully connect.
+		params += "sslmode=disable"
 	}
 
 	connStr := fmt.Sprintf("%s?%s", url, params)


### PR DESCRIPTION
Minor update to support running the [google/alloydbomni](https://hub.docker.com/r/google/alloydbomni/tags) image locally for local dev/testing.