### PR TITLE
Add struct context

### DIFF
--- a/log/README.md
+++ b/log/README.md
@@ -1,0 +1,122 @@
+# Log Package
+
+The log package provides structured logging capabilities for Moov applications.
+
+## Usage
+
+### Basic Logging
+
+```go
+import "github.com/moov-io/base/log"
+
+// Create a new logger
+logger := log.NewDefaultLogger()
+
+// Log a message with different levels
+logger.Info().Log("Application started")
+logger.Debug().Log("Debug information")
+logger.Warn().Log("Warning message")
+logger.Error().Log("Error occurred")
+
+// Log with key-value pairs
+logger.Info().Set("request_id", log.String("12345")).Log("Processing request")
+
+// Log formatted messages
+logger.Infof("Processing request %s", "12345")
+
+// Log errors
+err := someFunction()
+if err != nil {
+    logger.LogError(err)
+}
+```
+
+### Using Fields
+
+```go
+import "github.com/moov-io/base/log"
+
+// Create a map of fields
+fields := log.Fields{
+    "request_id": log.String("12345"),
+    "user_id":    log.Int(42),
+    "timestamp":  log.Time(time.Now()),
+}
+
+// Log with fields
+logger.With(fields).Info().Log("Request processed")
+```
+
+### Using StructContext
+
+The `StructContext` function allows you to log struct fields automatically by using tags.
+
+```go
+import "github.com/moov-io/base/log"
+
+// Define a struct with log tags
+type User struct {
+    ID       int    `log:"id"`
+    Username string `log:"username"`
+    Email    string `log:"email,omitempty"` // won't be logged if empty
+    Address  Address
+    Hidden   string // no log tag, won't be logged
+}
+
+type Address struct {
+    Street  string `log:"street"`
+    City    string `log:"city"`
+    Country string `log:"country"`
+}
+
+// Create a user
+user := User{
+    ID:       1,
+    Username: "johndoe",
+    Email:    "john@example.com",
+    Address: Address{
+        Street:  "123 Main St",
+        City:    "New York",
+        Country: "USA",
+    },
+    Hidden: "secret",
+}
+
+// Log with struct context
+logger.With(log.StructContext(user)).Info().Log("User logged in")
+
+// Log with struct context and prefix
+logger.With(log.StructContext(user, log.WithPrefix("user"))).Info().Log("User details")
+```
+
+The above will produce log entries with the following fields:
+- `id=1`
+- `username=johndoe`
+- `email=john@example.com`
+- `Address.street=123 Main St`
+- `Address.city=New York`
+- `Address.country=USA`
+
+With the prefix option, the fields will be:
+- `user.id=1`
+- `user.username=johndoe`
+- `user.email=john@example.com`
+- `user.Address.street=123 Main St`
+- `user.Address.city=New York`
+- `user.Address.country=USA`
+
+## Features
+
+- Structured logging with key-value pairs
+- Multiple log levels (Debug, Info, Warn, Error, Fatal)
+- JSON and LogFmt output formats
+- Context-based logging
+- Automatic struct field logging with StructContext
+- Support for various value types (string, int, float, bool, time, etc.)
+
+## Configuration
+
+The default logger format is determined by the `MOOV_LOG_FORMAT` environment variable:
+- `json`: JSON format
+- `logfmt`: LogFmt format (default)
+- `nop` or `noop`: No-op logger that discards all logs

--- a/log/README.md
+++ b/log/README.md
@@ -59,7 +59,7 @@ type User struct {
     ID       int    `log:"id"`
     Username string `log:"username"`
     Email    string `log:"email,omitempty"` // won't be logged if empty
-    Address  Address
+    Address  Address `log:"address"` // nested struct must have log tag
     Hidden   string // no log tag, won't be logged
 }
 
@@ -87,23 +87,46 @@ logger.With(log.StructContext(user)).Info().Log("User logged in")
 
 // Log with struct context and prefix
 logger.With(log.StructContext(user, log.WithPrefix("user"))).Info().Log("User details")
+
+// Using custom tag other than "log"
+type Product struct {
+    ID    int     `otel:"product_id"`
+    Name  string  `otel:"product_name"`
+    Price float64 `otel:"price,omitempty"`
+}
+
+product := Product{
+    ID:    42,
+    Name:  "Widget",
+    Price: 19.99,
+}
+
+// Use otel tags instead of log tags
+logger.With(log.StructContext(product, log.WithTag("otel"))).Info().Log("Product details")
 ```
 
 The above will produce log entries with the following fields:
 - `id=1`
 - `username=johndoe`
 - `email=john@example.com`
-- `Address.street=123 Main St`
-- `Address.city=New York`
-- `Address.country=USA`
+- `address.street=123 Main St`
+- `address.city=New York`
+- `address.country=USA`
 
 With the prefix option, the fields will be:
 - `user.id=1`
 - `user.username=johndoe`
 - `user.email=john@example.com`
-- `user.Address.street=123 Main St`
-- `user.Address.city=New York`
-- `user.Address.country=USA`
+- `user.address.street=123 Main St`
+- `user.address.city=New York`
+- `user.address.country=USA`
+
+With the custom tag option, the fields will be extracted from the tag you specify (such as `otel`):
+- `product_id=42`
+- `product_name=Widget`
+- `price=19.99`
+
+Note that nested structs or pointers to structs must have the specified tag to be included in the context.
 
 ## Features
 

--- a/log/struct_context.go
+++ b/log/struct_context.go
@@ -1,0 +1,202 @@
+package log
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+	"time"
+)
+
+// StructContextOption defines options for StructContext
+type StructContextOption func(*structContext)
+
+// WithPrefix adds a prefix to all struct field names
+func WithPrefix(prefix string) StructContextOption {
+	return func(sc *structContext) {
+		sc.prefix = prefix
+	}
+}
+
+// structContext implements the Context interface for struct fields
+type structContext struct {
+	fields map[string]Valuer
+	prefix string
+}
+
+// Context returns a map of field names to Valuer implementations
+func (sc *structContext) Context() map[string]Valuer {
+	return sc.fields
+}
+
+// StructContext creates a Context from a struct, extracting fields tagged with `log`
+// It supports nested structs and respects omitempty directive
+func StructContext(v interface{}, opts ...StructContextOption) Context {
+	sc := &structContext{
+		fields: make(map[string]Valuer),
+	}
+
+	// Apply options
+	for _, opt := range opts {
+		opt(sc)
+	}
+
+	if v == nil {
+		return sc
+	}
+
+	value := reflect.ValueOf(v)
+	extractFields(value, sc.fields, sc.prefix, "")
+
+	return sc
+}
+
+// extractFields recursively extracts fields from a struct value
+func extractFields(value reflect.Value, fields map[string]Valuer, prefix, path string) {
+	// If it's a pointer, dereference it
+	if value.Kind() == reflect.Ptr {
+		if value.IsNil() {
+			return
+		}
+		value = value.Elem()
+	}
+
+	// Only process structs
+	if value.Kind() != reflect.Struct {
+		return
+	}
+
+	typ := value.Type()
+	for i := 0; i < typ.NumField(); i++ {
+		field := typ.Field(i)
+		fieldValue := value.Field(i)
+
+		// Skip unexported fields
+		if !field.IsExported() {
+			continue
+		}
+
+		// Get the log tag
+		tag := field.Tag.Get("log")
+		if tag == "" {
+			// If the field is a struct, recursively extract its fields
+			if fieldValue.Kind() == reflect.Struct || 
+				(fieldValue.Kind() == reflect.Ptr && !fieldValue.IsNil() && fieldValue.Elem().Kind() == reflect.Struct) {
+				// Use field name for the path
+				newPath := field.Name
+				if path != "" {
+					newPath = path + "." + field.Name
+				}
+				extractFields(fieldValue, fields, prefix, newPath)
+			}
+			continue
+		}
+
+		// Parse the tag
+		tagParts := strings.Split(tag, ",")
+		fieldName := tagParts[0]
+		if fieldName == "" {
+			fieldName = field.Name
+		}
+
+		// Handle omitempty
+		omitEmpty := false
+		for _, opt := range tagParts[1:] {
+			if opt == "omitempty" {
+				omitEmpty = true
+				break
+			}
+		}
+
+		// Build the full field name with path and prefix
+		fullName := fieldName
+		if path != "" {
+			fullName = path + "." + fieldName
+		}
+		if prefix != "" {
+			fullName = prefix + "." + fullName
+		}
+
+		// Check if field should be omitted due to empty value
+		if omitEmpty && isEmptyValue(fieldValue) {
+			continue
+		}
+
+		// Store the field value
+		valuer := valueToValuer(fieldValue)
+		if valuer != nil {
+			fields[fullName] = valuer
+		}
+
+		// If it's a struct, also extract its fields recursively
+		if fieldValue.Kind() == reflect.Struct || 
+			(fieldValue.Kind() == reflect.Ptr && !fieldValue.IsNil() && fieldValue.Elem().Kind() == reflect.Struct) {
+			extractFields(fieldValue, fields, prefix, fullName)
+		}
+	}
+}
+
+// isEmptyValue checks if a value is considered empty
+func isEmptyValue(v reflect.Value) bool {
+	switch v.Kind() {
+	case reflect.Array, reflect.Map, reflect.Slice, reflect.String:
+		return v.Len() == 0
+	case reflect.Bool:
+		return !v.Bool()
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return v.Int() == 0
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+		return v.Uint() == 0
+	case reflect.Float32, reflect.Float64:
+		return v.Float() == 0
+	case reflect.Interface, reflect.Ptr:
+		return v.IsNil()
+	}
+	return false
+}
+
+// valueToValuer converts a reflect.Value to a Valuer
+func valueToValuer(v reflect.Value) Valuer {
+	if !v.IsValid() {
+		return nil
+	}
+
+	switch v.Kind() {
+	case reflect.Bool:
+		return Bool(v.Bool())
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return Int64(v.Int())
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		return Uint64(v.Uint())
+	case reflect.Float32:
+		return Float32(float32(v.Float()))
+	case reflect.Float64:
+		return Float64(v.Float())
+	case reflect.String:
+		return String(v.String())
+	case reflect.Ptr:
+		if v.IsNil() {
+			return &any{nil}
+		}
+		return valueToValuer(v.Elem())
+	case reflect.Struct:
+		// Check if it's a time.Time
+		if v.Type().String() == "time.Time" {
+			if v.CanInterface() {
+				t, ok := v.Interface().(time.Time)
+				if ok {
+					return Time(t)
+				}
+			}
+		}
+	}
+
+	// Try to use Stringer for complex types
+	if v.CanInterface() {
+		if stringer, ok := v.Interface().(fmt.Stringer); ok {
+			return Stringer(stringer)
+		}
+	}
+
+	// Return as string representation for other types
+	return String(fmt.Sprintf("%v", v.Interface()))
+}

--- a/log/struct_context.go
+++ b/log/struct_context.go
@@ -139,6 +139,7 @@ func valueToValuer(v reflect.Value) Valuer {
 		return nil
 	}
 
+	//nolint:exhaustive
 	switch v.Kind() {
 	case reflect.Bool:
 		return Bool(v.Bool())
@@ -179,4 +180,3 @@ func valueToValuer(v reflect.Value) Valuer {
 	// Return as string representation for other types
 	return String(fmt.Sprintf("%v", v.Interface()))
 }
-

--- a/log/struct_context_test.go
+++ b/log/struct_context_test.go
@@ -1,0 +1,180 @@
+package log
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestStructContext(t *testing.T) {
+	type Address struct {
+		Street  string `log:"street"`
+		City    string `log:"city"`
+		Country string `log:"country"`
+		ZipCode string `log:"zip_code,omitempty"`
+	}
+
+	type Person struct {
+		Name      string    `log:"name"`
+		Age       int       `log:"age"`
+		Email     string    `log:"email,omitempty"`
+		CreatedAt time.Time `log:"created_at"`
+		Address   Address
+		Hidden    string
+	}
+
+	now := time.Now()
+	p := Person{
+		Name:      "John Doe",
+		Age:       30,
+		Email:     "john@example.com",
+		CreatedAt: now,
+		Address: Address{
+			Street:  "123 Main St",
+			City:    "New York",
+			Country: "USA",
+		},
+		Hidden: "should not appear",
+	}
+
+	// Test basic struct context
+	ctx := StructContext(p)
+	fields := ctx.Context()
+
+	require.Equal(t, 7, len(fields))
+	require.Equal(t, "John Doe", fields["name"].getValue())
+	require.Equal(t, int64(30), fields["age"].getValue())
+	require.Equal(t, "john@example.com", fields["email"].getValue())
+	require.Equal(t, now.Format(time.RFC3339Nano), fields["created_at"].getValue())
+	require.Equal(t, "123 Main St", fields["Address.street"].getValue())
+	require.Equal(t, "New York", fields["Address.city"].getValue())
+	require.Equal(t, "USA", fields["Address.country"].getValue())
+	require.NotContains(t, fields, "Hidden")
+	require.NotContains(t, fields, "Address.zip_code") // Should be omitted as it's empty
+
+	// Test with prefix
+	ctx = StructContext(p, WithPrefix("user"))
+	fields = ctx.Context()
+
+	require.Equal(t, 7, len(fields))
+	require.Equal(t, "John Doe", fields["user.name"].getValue())
+	require.Equal(t, int64(30), fields["user.age"].getValue())
+	require.Equal(t, "john@example.com", fields["user.email"].getValue())
+	require.Equal(t, now.Format(time.RFC3339Nano), fields["user.created_at"].getValue())
+	require.Equal(t, "123 Main St", fields["user.Address.street"].getValue())
+	require.Equal(t, "New York", fields["user.Address.city"].getValue())
+	require.Equal(t, "USA", fields["user.Address.country"].getValue())
+
+	// Test with nil value
+	ctx = StructContext(nil)
+	require.Empty(t, ctx.Context())
+
+	// Test omitempty behavior
+	p.Email = ""
+	ctx = StructContext(p)
+	fields = ctx.Context()
+	require.NotContains(t, fields, "email") // Should be omitted as it's empty
+
+	// Test with pointer to struct
+	ctx = StructContext(&p)
+	fields = ctx.Context()
+	require.Equal(t, 6, len(fields)) // email is empty and omitted
+	require.Equal(t, "John Doe", fields["name"].getValue())
+
+	// Test nested pointer structs
+	type Department struct {
+		Name string `log:"name"`
+	}
+
+	type Company struct {
+		Dept *Department `log:"department"`
+	}
+
+	type Employee struct {
+		Company *Company
+	}
+
+	employee := Employee{
+		Company: &Company{
+			Dept: &Department{
+				Name: "Engineering",
+			},
+		},
+	}
+
+	ctx = StructContext(employee)
+	fields = ctx.Context()
+	require.Equal(t, 2, len(fields))
+	require.Equal(t, "Engineering", fields["Company.department.name"].getValue())
+
+	// Test with various value types
+	type AllTypes struct {
+		BoolVal    bool    `log:"bool"`
+		IntVal     int     `log:"int"`
+		Int64Val   int64   `log:"int64"`
+		UintVal    uint    `log:"uint"`
+		Uint64Val  uint64  `log:"uint64"`
+		Float32Val float32 `log:"float32"`
+		Float64Val float64 `log:"float64"`
+		StringVal  string  `log:"string"`
+	}
+
+	allTypes := AllTypes{
+		BoolVal:    true,
+		IntVal:     42,
+		Int64Val:   int64(9223372036854775807),
+		UintVal:    42,
+		Uint64Val:  uint64(18446744073709551615),
+		Float32Val: 3.14,
+		Float64Val: 2.71828,
+		StringVal:  "hello",
+	}
+
+	ctx = StructContext(allTypes)
+	fields = ctx.Context()
+	require.Equal(t, 8, len(fields))
+	require.Equal(t, true, fields["bool"].getValue())
+	require.Equal(t, int64(42), fields["int"].getValue())
+	require.Equal(t, int64(9223372036854775807), fields["int64"].getValue())
+	require.Equal(t, uint64(42), fields["uint"].getValue())
+	require.Equal(t, uint64(18446744073709551615), fields["uint64"].getValue())
+	require.Equal(t, float32(3.14), fields["float32"].getValue())
+	require.Equal(t, float64(2.71828), fields["float64"].getValue())
+	require.Equal(t, "hello", fields["string"].getValue())
+}
+
+func TestStructContextWithLogger(t *testing.T) {
+	type User struct {
+		ID       int    `log:"id"`
+		Username string `log:"username"`
+		Email    string `log:"email,omitempty"`
+	}
+
+	buffer, logger := NewBufferLogger()
+	user := User{
+		ID:       1,
+		Username: "johndoe",
+		Email:    "john@example.com",
+	}
+
+	// Log with struct context
+	logger.With(StructContext(user)).Info().Log("User logged in")
+
+	// Check log output
+	output := buffer.String()
+	require.Contains(t, output, "username=johndoe")
+	require.Contains(t, output, "id=1")
+	require.Contains(t, output, "email=john@example.com")
+	require.Contains(t, output, "level=info")
+	require.Contains(t, output, "msg=\"User logged in\"")
+
+	// Test with prefix
+	buffer.Reset()
+	logger.With(StructContext(user, WithPrefix("user"))).Info().Log("User details")
+
+	output = buffer.String()
+	require.Contains(t, output, "user.username=johndoe")
+	require.Contains(t, output, "user.id=1")
+	require.Contains(t, output, "user.email=john@example.com")
+}


### PR DESCRIPTION
Add the `StructContext` function that allows to log struct fields automatically by using tags.


```go
import "github.com/moov-io/base/log"

// Define a struct with log tags
type User struct {
    ID       int    `log:"id"`
    Username string `log:"username"`
    Email    string `log:"email,omitempty"` // won't be logged if empty
    Address  Address `log:"address"` // nested struct must have log tag
    Hidden   string // no log tag, won't be logged
}

//...
// Log with struct context
logger.With(log.StructContext(user)).Info().Log("User logged in")
```
