### PR TITLE
Update skip and count methods to support either http.Request or input string

### DIFF
--- a/http/server.go
+++ b/http/server.go
@@ -140,7 +140,7 @@ func readSkipCount[T *http.Request | string](t T, skipMax, countMax int) (skip i
 	case string:
 		query, err = url.ParseQuery(tt)
 		if err != nil {
-			return skip, count, exists, fmt.Errorf("parsing query: %w", err)
+			return skip, count, exists, fmt.Errorf("parsing query string: %w", err)
 		}
 	default:
 		return skip, count, exists, fmt.Errorf("unsupported type %T for reading skip and count", t)


### PR DESCRIPTION
### Context
We have a use-case where we need to call `LimitedSkipAndCount`, but don't have a full `*http.Request` to pass in -- because the codepath stems from a gRPC request. But we do have the raw query string.

### Solution
To handle this, we should be able to take advantage of generics and update `GetSkipAndCount` and `LimitedSkipCount` to accept either a `*http.Request` or `string`.

Benefit of this approach is this update should not be a breaking change for dependent repos.