### PR TITLE
feat: add retryable DB operations

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,7 +35,7 @@ services:
       - "5432:5432"
     # https://github.com/docker-library/postgres/issues/1059#issuecomment-1467077098
     command: |
-      sh -c 'chown postgres:postgres /opt/moov/certs/*.key && chmod 0644 /opt/moov/certs/*.crt && ls -l /opt/moov/certs/ && exec docker-entrypoint.sh -c ssl=on -c ssl_cert_file=/opt/moov/certs/server.crt -c ssl_key_file=/opt/moov/certs/server.key -c ssl_ca_file=/opt/moov/certs/root.crt'
+      sh -c 'chown postgres:postgres /opt/moov/certs/*.key && chmod 0600 /opt/moov/certs/*.crt && chmod 0600 /opt/moov/certs/*.key && ls -l /opt/moov/certs/ && exec docker-entrypoint.sh -c ssl=on -c ssl_cert_file=/opt/moov/certs/server.crt -c ssl_key_file=/opt/moov/certs/server.key -c ssl_ca_file=/opt/moov/certs/root.crt'
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U moov"]
       interval: 5s

--- a/ratex/ratelimit.go
+++ b/ratex/ratelimit.go
@@ -1,0 +1,148 @@
+package ratex
+
+import (
+	"context"
+	"crypto/rand"
+	"fmt"
+	"math/big"
+	"time"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+	"golang.org/x/time/rate"
+
+	"github.com/moov-io/base/telemetry"
+)
+
+type RateLimitParams struct {
+	RateLimiter *rate.Limiter // can be nil to create a new rate limiter
+	TryCount    int           `otel:"try_count"`
+	MinDuration time.Duration `otel:"min_duration_n"`
+	MaxDuration time.Duration `otel:"max_duration_ns"`
+}
+
+func RateLimit(ctx context.Context, params RateLimitParams) (*rate.Limiter, error) {
+	ctx, span := telemetry.StartSpan(ctx, "rate-limiter-wait",
+		trace.WithAttributes(telemetry.StructAttributes(params)...))
+	defer span.End()
+
+	var (
+		err error
+	)
+
+	params.RateLimiter, err = generateRateLimiter(ctx, params)
+	if err != nil {
+		return nil, fmt.Errorf("generating rate limiter: %w", err)
+	}
+
+	err = params.RateLimiter.Wait(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("rate limiter wait: %w", err)
+	}
+
+	return params.RateLimiter, nil
+}
+
+// generateRateLimiter initializes a new rate limiter or sets a new limit on it.
+func generateRateLimiter(ctx context.Context, params RateLimitParams) (*rate.Limiter, error) {
+	rateLimitDuration, err := generateRateLimitDuration(params.TryCount, params.MinDuration, params.MaxDuration)
+	if err != nil {
+		return nil, fmt.Errorf("generating rate limit duration: %w", err)
+	}
+
+	rateLimitInterval := rate.Every(rateLimitDuration)
+	if params.RateLimiter == nil {
+		params.RateLimiter = rate.NewLimiter(rateLimitInterval, 1)
+		// A rate limiter is initialized with 1 token. So the first call to Wait will not wait/block, only subsequent calls to Wait will.
+		// Call wait immediately after initializing to use up token and ensure we trigger a delay on next call to Wait.
+		if err := params.RateLimiter.Wait(ctx); err != nil {
+			return nil, fmt.Errorf("rate limiter wait: %w", err)
+		}
+	} else {
+		params.RateLimiter.SetLimit(rateLimitInterval)
+	}
+
+	return params.RateLimiter, nil
+}
+
+// generateRateLimitDuration returns a random value between min-max duration multiplied by the multiplier.
+func generateRateLimitDuration(multiplier int, minDuration, maxDuration time.Duration) (time.Duration, error) {
+	minVal := minDuration.Milliseconds()
+	maxVal := maxDuration.Milliseconds()
+
+	maxRand, err := rand.Int(rand.Reader, big.NewInt(maxVal-minVal))
+	if err != nil {
+		return 0, fmt.Errorf("rand int: %w", err)
+	}
+	waitInterval := (minVal + maxRand.Int64()) * int64(multiplier)
+	return time.Millisecond * time.Duration(waitInterval), nil
+}
+
+type RetryParams struct {
+	ShouldRetry func(err error) bool
+	MaxRetries  int           `otel:"max_retries"`
+	MinDuration time.Duration `otel:"min_duration_n"`
+	MaxDuration time.Duration `otel:"max_duration_ns"`
+}
+
+func ExecRetryable[R any](ctx context.Context, closure func(ctx context.Context) (R, error), params RetryParams) (R, error) {
+	var (
+		rateLimiter *rate.Limiter
+		retVal      R
+		err         error
+	)
+
+	tryFunc := func(ctx context.Context, tryCount int) (R, error) {
+		tryCtx, span := telemetry.StartSpan(ctx, "try",
+			trace.WithAttributes(
+				attribute.Int("try_count", tryCount),
+				attribute.Int("max_tries", params.MaxRetries),
+			),
+		)
+		defer span.End()
+		return closure(tryCtx)
+	}
+
+	for i := range params.MaxRetries {
+		tryCount := i + 1
+		retVal, err = tryFunc(ctx, tryCount)
+
+		// no error means success - break out
+		if err == nil {
+			break
+		}
+
+		// if the error doesn't have one of the flags do not retry, instead return the error
+		if !params.ShouldRetry(err) {
+			return retVal, err
+		}
+
+		// record event if we'll be attempting retries
+		err = fmt.Errorf("try %d of %d: %w", tryCount, params.MaxRetries, err)
+		telemetry.AddEvent(ctx, err.Error())
+
+		if tryCount != params.MaxRetries {
+			// If error and we haven't hit max tries,
+			// generate rate limiter to delay retries.
+			// This will jitter a wait time before the next iteration.
+			//
+			// We continue on rate limit errors and retry without waiting
+			params := RateLimitParams{
+				RateLimiter: rateLimiter,
+				TryCount:    tryCount,
+				MinDuration: params.MinDuration,
+				MaxDuration: params.MaxDuration,
+			}
+			rateLimiter, err = RateLimit(ctx, params)
+			if err != nil {
+				telemetry.AddEvent(ctx, fmt.Sprintf("rate limit: %s", err.Error()))
+				continue
+			}
+		}
+	}
+
+	if err != nil {
+		return retVal, fmt.Errorf("hit max tries %d: %w", params.MaxRetries, err)
+	}
+	return retVal, nil
+}

--- a/ratex/ratelimit_test.go
+++ b/ratex/ratelimit_test.go
@@ -1,0 +1,81 @@
+package ratex
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestExecRetryable(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("Success on first try", func(t *testing.T) {
+		closure := func(ctx context.Context) (string, error) {
+			return "success", nil
+		}
+		params := RetryParams{
+			ShouldRetry: func(err error) bool { return true },
+			MaxRetries:  3,
+			MinDuration: 10 * time.Millisecond,
+			MaxDuration: 50 * time.Millisecond,
+		}
+		result, err := ExecRetryable(ctx, closure, params)
+		require.NoErrorf(t, err, "Expected success, got error: %v", err)
+		require.Equalf(t, "success", result, "Expected result 'success', got: %v", result)
+	})
+
+	t.Run("Retryable failure with success before last retry", func(t *testing.T) {
+		attempts := 0
+		closure := func(ctx context.Context) (string, error) {
+			if attempts < 2 {
+				attempts++
+				return "", errors.New("retryable error")
+			}
+			return "success", nil
+		}
+		params := RetryParams{
+			ShouldRetry: func(err error) bool { return true },
+			MaxRetries:  3,
+			MinDuration: 10 * time.Millisecond,
+			MaxDuration: 50 * time.Millisecond,
+		}
+		result, err := ExecRetryable(ctx, closure, params)
+		require.NoErrorf(t, err, "Expected success, got error: %v", err)
+		require.Equalf(t, "success", result, "Expected result 'success', got: %v", result)
+	})
+
+	t.Run("Non-retryable failure", func(t *testing.T) {
+		closure := func(ctx context.Context) (string, error) {
+			return "", errors.New("non-retryable error")
+		}
+		params := RetryParams{
+			ShouldRetry: func(err error) bool { return false },
+			MaxRetries:  3,
+			MinDuration: 10 * time.Millisecond,
+			MaxDuration: 50 * time.Millisecond,
+		}
+		result, err := ExecRetryable(ctx, closure, params)
+		require.Errorf(t, err, "Expected non-retryable error, got: %v", err)
+		require.Empty(t, result)
+		require.Equal(t, "non-retryable error", err.Error())
+	})
+
+	t.Run("Retryable failures exceeding MaxRetries", func(t *testing.T) {
+		closure := func(ctx context.Context) (string, error) {
+			return "", errors.New("retryable error")
+		}
+		params := RetryParams{
+			ShouldRetry: func(err error) bool { return true },
+			MaxRetries:  3,
+			MinDuration: 10 * time.Millisecond,
+			MaxDuration: 50 * time.Millisecond,
+		}
+		result, err := ExecRetryable(ctx, closure, params)
+		require.Errorf(t, err, "Expected error after exceeding max retries, got: %v", err)
+		require.Empty(t, result)
+		require.Equal(t, "hit max tries 3: try 3 of 3: retryable error", err.Error())
+	})
+}

--- a/sql/db.go
+++ b/sql/db.go
@@ -65,7 +65,7 @@ func (w *DB) PrepareContext(ctx context.Context, query string) (*Stmt, error) {
 	return newStmt(ctx, w.logger, w.DB, query, w.id, w.slowQueryThresholdMs)
 }
 
-func (w *DB) Exec(query string, args ...interface{}) (gosql.Result, error) {
+func (w *DB) Exec(query string, args ...any) (gosql.Result, error) {
 	done := w.start("exec", query, len(args))
 	defer done()
 
@@ -73,7 +73,7 @@ func (w *DB) Exec(query string, args ...interface{}) (gosql.Result, error) {
 	return r, w.error(err)
 }
 
-func (w *DB) ExecContext(ctx context.Context, query string, args ...interface{}) (gosql.Result, error) {
+func (w *DB) ExecContext(ctx context.Context, query string, args ...any) (gosql.Result, error) {
 	done := w.start("exec", query, len(args))
 	ctx, end := span(ctx, w.id, "exec", query, len(args))
 	defer func() {
@@ -85,7 +85,7 @@ func (w *DB) ExecContext(ctx context.Context, query string, args ...interface{})
 	return r, w.error(err)
 }
 
-func (w *DB) Query(query string, args ...interface{}) (*gosql.Rows, error) {
+func (w *DB) Query(query string, args ...any) (*gosql.Rows, error) {
 	done := w.start("query", query, len(args))
 	defer done()
 
@@ -94,7 +94,7 @@ func (w *DB) Query(query string, args ...interface{}) (*gosql.Rows, error) {
 	return r, w.error(err)
 }
 
-func (w *DB) QueryContext(ctx context.Context, query string, args ...interface{}) (*gosql.Rows, error) {
+func (w *DB) QueryContext(ctx context.Context, query string, args ...any) (*gosql.Rows, error) {
 	done := w.start("query", query, len(args))
 	ctx, end := span(ctx, w.id, "query", query, len(args))
 	defer func() {
@@ -106,7 +106,7 @@ func (w *DB) QueryContext(ctx context.Context, query string, args ...interface{}
 	return r, w.error(err)
 }
 
-func (w *DB) QueryRow(query string, args ...interface{}) *gosql.Row {
+func (w *DB) QueryRow(query string, args ...any) *gosql.Row {
 	done := w.start("query-row", query, len(args))
 	defer done()
 
@@ -116,7 +116,7 @@ func (w *DB) QueryRow(query string, args ...interface{}) *gosql.Row {
 	return r
 }
 
-func (w *DB) QueryRowContext(ctx context.Context, query string, args ...interface{}) *gosql.Row {
+func (w *DB) QueryRowContext(ctx context.Context, query string, args ...any) *gosql.Row {
 	done := w.start("query-row", query, len(args))
 	ctx, end := span(ctx, w.id, "query-row", query, len(args))
 	defer func() {

--- a/sql/tx.go
+++ b/sql/tx.go
@@ -92,7 +92,7 @@ func (w *Tx) finished() {
 	w.done()
 }
 
-func (w *Tx) ExecContext(ctx context.Context, query string, args ...interface{}) (gosql.Result, error) {
+func (w *Tx) ExecContext(ctx context.Context, query string, args ...any) (gosql.Result, error) {
 	done := w.start("exec", query, len(args))
 	defer done()
 
@@ -100,7 +100,7 @@ func (w *Tx) ExecContext(ctx context.Context, query string, args ...interface{})
 	return r, w.error(err)
 }
 
-func (w *Tx) Exec(query string, args ...interface{}) (gosql.Result, error) {
+func (w *Tx) Exec(query string, args ...any) (gosql.Result, error) {
 	done := w.start("exec", query, len(args))
 	defer done()
 
@@ -108,7 +108,7 @@ func (w *Tx) Exec(query string, args ...interface{}) (gosql.Result, error) {
 	return r, w.error(err)
 }
 
-func (w *Tx) QueryContext(ctx context.Context, query string, args ...interface{}) (*gosql.Rows, error) {
+func (w *Tx) QueryContext(ctx context.Context, query string, args ...any) (*gosql.Rows, error) {
 	done := w.start("query", query, len(args))
 	defer done()
 
@@ -116,7 +116,7 @@ func (w *Tx) QueryContext(ctx context.Context, query string, args ...interface{}
 	return r, w.error(err)
 }
 
-func (w *Tx) Query(query string, args ...interface{}) (*gosql.Rows, error) {
+func (w *Tx) Query(query string, args ...any) (*gosql.Rows, error) {
 	done := w.start("query", query, len(args))
 	defer done()
 
@@ -124,7 +124,7 @@ func (w *Tx) Query(query string, args ...interface{}) (*gosql.Rows, error) {
 	return r, w.error(err)
 }
 
-func (w *Tx) QueryRowContext(ctx context.Context, query string, args ...interface{}) *gosql.Row {
+func (w *Tx) QueryRowContext(ctx context.Context, query string, args ...any) *gosql.Row {
 	done := w.start("query-row", query, len(args))
 	defer done()
 
@@ -134,7 +134,7 @@ func (w *Tx) QueryRowContext(ctx context.Context, query string, args ...interfac
 	return r
 }
 
-func (w *Tx) QueryRow(query string, args ...interface{}) *gosql.Row {
+func (w *Tx) QueryRow(query string, args ...any) *gosql.Row {
 	done := w.start("query-row", query, len(args))
 	defer done()
 


### PR DESCRIPTION
There are certain cases where a DB-level retry is desired, namely those related to temporary connectivity issues to the database itself. This PR adds a generic rate-limited retry function as well as extensions to `DB` for retryable queries.