### PR TITLE
fix(database): Postgres pool review follow-ups from #490

### DIFF
--- a/database/database.go
+++ b/database/database.go
@@ -91,19 +91,6 @@ func DeadlockFound(err error) bool {
 	return MySQLDeadlockFound(err) || PostgresDeadlockFound(err)
 }
 
-// ApplyPostgresConnectionsConfig applies connection pool settings onto a *sql.DB.
-//
-// Deprecated: Postgres connections from New use pgxpool under the hood. Pool
-// settings are applied via ApplyPostgresPoolConfig inside postgresConnection.
-// Calling this on a Postgres *sql.DB from New is incorrect: SetMaxIdleConns
-// with a non-zero value breaks OpenDBFromPool, and the other setters do not
-// configure the underlying pgxpool. Prefer ConnectionsConfig on PostgresConfig
-// (applied automatically) or ApplyPostgresPoolConfig when building a pool.
-func ApplyPostgresConnectionsConfig(db *sql.DB, connections *ConnectionsConfig, logger log.Logger) *sql.DB {
-	applied := ResolvePostgresConnectionsConfig(*connections)
-	return ApplyConnectionsConfig(db, &applied, logger)
-}
-
 func ApplyConnectionsConfig(db *sql.DB, connections *ConnectionsConfig, logger log.Logger) *sql.DB {
 	if connections.MaxOpen > 0 {
 		logger.Logf("setting SQL max open connections to %d", connections.MaxOpen)

--- a/database/model_config.go
+++ b/database/model_config.go
@@ -137,10 +137,11 @@ type RetryConfig struct {
 //   - MaxOpen (25): pgxpool always has a finite MaxConns. Unset MaxOpen no
 //     longer means unlimited — it becomes 25. High-concurrency services must
 //     set PostgresConfig.Connections.MaxOpen explicitly if they need more.
-//   - MaxLifetime (5m): connections are recycled after this age (pgxpool
-//     adds jitter). Unset previously meant no max lifetime. Shorter lifetime
-//     helps drop stale sockets after AlloyDB failover; increase if reconnect
-//     cost (for example AlloyDB IAM) is more expensive than churn.
+//   - MaxLifetime (5m): connections are recycled after this age. ApplyPostgresPoolConfig
+//     also sets MaxConnLifetimeJitter (pgxpool defaults it to 0) so recycling is
+//     staggered. Unset previously meant no max lifetime. Shorter lifetime helps
+//     drop stale sockets after AlloyDB failover; increase if reconnect cost
+//     (for example AlloyDB IAM) is more expensive than churn.
 //   - MaxIdleTime (2m): idle connections are closed after this duration.
 //     Unset previously meant keep idle forever. Quiet processes will
 //     reconnect after idle gaps; raise this if cold-connect latency matters.

--- a/database/postgres.go
+++ b/database/postgres.go
@@ -28,7 +28,16 @@ const (
 	// Bound ShouldPing wait so acquire retries during failover stay inside
 	// typical request budgets. AlloyDB disconnects usually fail fast (TCP RST);
 	// this caps hung/TIME_WAIT peers.
-	defaultPostgresPingTimeout = time.Second
+	//
+	// Keep this low: Pool.Acquire retries up to maxConns+1 times, and each
+	// failed ping can burn the full timeout. At MaxOpen=25 and 1s that is a
+	// theoretical ~26s blackhole path; 300ms keeps a full-pool burn nearer a
+	// typical request budget while still covering real ping RTT.
+	defaultPostgresPingTimeout = 300 * time.Millisecond
+
+	// pgxpool defaults MaxConnLifetimeJitter to 0. Without jitter, every
+	// connection created around the same time can expire together.
+	defaultPostgresMaxConnLifetimeJitter = 30 * time.Second
 )
 
 func postgresConnection(ctx context.Context, logger log.Logger, config PostgresConfig, databaseName string) (*sql.DB, error) {
@@ -114,6 +123,18 @@ func ApplyPostgresPoolConfig(logger log.Logger, poolConfig *pgxpool.Config, conn
 
 	logger.Logf("setting pgx pool MaxConnLifetime to %v", applied.MaxLifetime)
 	poolConfig.MaxConnLifetime = applied.MaxLifetime
+
+	// MaxConnLifetimeJitter defaults to 0 in pgxpool (not automatic). Only fill
+	// when unset so a DSN/pool_max_conn_lifetime_jitter still wins.
+	if poolConfig.MaxConnLifetimeJitter <= 0 {
+		jitter := defaultPostgresMaxConnLifetimeJitter
+		// Prefer ~10% of lifetime when that is larger than the fixed default.
+		if tenth := applied.MaxLifetime / 10; tenth > jitter {
+			jitter = tenth
+		}
+		logger.Logf("setting pgx pool MaxConnLifetimeJitter to %v", jitter)
+		poolConfig.MaxConnLifetimeJitter = jitter
+	}
 }
 
 // ResolvePostgresConnectionsConfig returns connections with zero-valued fields

--- a/database/postgres_pool_test.go
+++ b/database/postgres_pool_test.go
@@ -65,6 +65,7 @@ func TestApplyPostgresPoolConfig_Defaults(t *testing.T) {
 
 	// Start from pgxpool's own defaults so we can see our overrides.
 	require.NotEqual(t, int32(DefaultPostgresConnectionsConfig().MaxOpen), poolConfig.MaxConns)
+	require.Equal(t, time.Duration(0), poolConfig.MaxConnLifetimeJitter)
 
 	ApplyPostgresPoolConfig(log.NewTestLogger(), poolConfig, ConnectionsConfig{})
 
@@ -72,6 +73,8 @@ func TestApplyPostgresPoolConfig_Defaults(t *testing.T) {
 	require.Equal(t, int32(defaults.MaxOpen), poolConfig.MaxConns)
 	require.Equal(t, defaults.MaxLifetime, poolConfig.MaxConnLifetime)
 	require.Equal(t, defaults.MaxIdleTime, poolConfig.MaxConnIdleTime)
+	// pgxpool does not default jitter; we fill it so lifetime recycle is staggered.
+	require.Equal(t, defaultPostgresMaxConnLifetimeJitter, poolConfig.MaxConnLifetimeJitter)
 }
 
 func TestApplyPostgresPoolConfig_Overrides(t *testing.T) {
@@ -95,6 +98,27 @@ func TestApplyPostgresPoolConfig_Overrides(t *testing.T) {
 	require.Equal(t, 90*time.Second, poolConfig.MaxConnIdleTime)
 	require.Equal(t, minConnsBefore, poolConfig.MinConns)
 	require.Equal(t, minIdleBefore, poolConfig.MinIdleConns)
+	// 10% of 20m = 2m > fixed 30s default.
+	require.Equal(t, 2*time.Minute, poolConfig.MaxConnLifetimeJitter)
+}
+
+func TestApplyPostgresPoolConfig_PreservesConfiguredJitter(t *testing.T) {
+	poolConfig, err := pgxpool.ParseConfig("postgres://user:pass@127.0.0.1:1/db?sslmode=disable")
+	require.NoError(t, err)
+	poolConfig.MaxConnLifetimeJitter = 45 * time.Second
+
+	ApplyPostgresPoolConfig(log.NewTestLogger(), poolConfig, ConnectionsConfig{})
+
+	require.Equal(t, 45*time.Second, poolConfig.MaxConnLifetimeJitter)
+}
+
+func TestDefaultPostgresPingTimeout(t *testing.T) {
+	// Document the acquire worst-case: (MaxOpen+1) * PingTimeout should stay
+	// well under a long request budget for blackholed peers.
+	require.Equal(t, 300*time.Millisecond, defaultPostgresPingTimeout)
+	maxOpen := DefaultPostgresConnectionsConfig().MaxOpen
+	worstCase := time.Duration(maxOpen+1) * defaultPostgresPingTimeout
+	require.LessOrEqual(t, worstCase, 10*time.Second)
 }
 
 func TestApplyPostgresPoolConfig_ClampsMaxOpenToInt32(t *testing.T) {


### PR DESCRIPTION
## Summary

Follow-ups from [@atonks2's review on #490](https://github.com/moov-io/base/pull/490#pullrequestreview-4885529567) (and the Grok replies on those threads):

1. **`PingTimeout` 1s → 300ms**  
   `Pool.Acquire` retries up to `maxConns+1` times; each failed `ShouldPing` can burn the full timeout. With `MaxOpen=25` and 1s that is a theoretical ~26s blackhole path. 300ms still covers real ping RTT while keeping a full-pool burn nearer a request budget.

2. **Remove `ApplyPostgresConnectionsConfig`**  
   Deprecated helper that applied settings to `*sql.DB` (including `SetMaxIdleConns`), which is wrong/dangerous for the pgxpool path. No in-repo callers; correct APIs are `PostgresConfig.Connections` / `ApplyPostgresPoolConfig`.

3. **`MaxConnLifetimeJitter`**  
   pgxpool defaults jitter to **0** — it is not automatic. `ApplyPostgresPoolConfig` now sets jitter when unset (max of 30s and 10% of `MaxConnLifetime`), and preserves an already-configured value (e.g. DSN). Godoc updated accordingly.

## Test plan

- [x] `go test ./database/ -short -run 'TestResolve|TestApply|TestOpenDB|TestDefaultPostgres'`
- [ ] Confirm no external Moov services import `ApplyPostgresConnectionsConfig` before merge (grep looked clean under `moov-io/` checkout)