### PR TITLE
feat(database): expose PoolDBStats for pgxpool-backed Postgres

### DIFF
--- a/database/model_config.go
+++ b/database/model_config.go
@@ -34,6 +34,9 @@ type SpannerConfig struct {
 //   - Connections.MaxIdle has no pgxpool equivalent and is ignored (logged when set).
 //   - Do not call sql.DB SetMaxIdleConns with a non-zero value on the returned DB;
 //     OpenDBFromPool requires MaxIdleConns=0 so connections return to pgxpool.
+//   - db.Stats() is not meaningful for capacity (sql.DB does not hold the pool).
+//     Use PoolDBStats(db) for real pgxpool pressure (wired into go-libs
+//     observability/sql MeasureStats when present).
 type PostgresConfig struct {
 	Address     string
 	User        string

--- a/database/postgres.go
+++ b/database/postgres.go
@@ -134,6 +134,10 @@ func ResolvePostgresConnectionsConfig(connections ConnectionsConfig) Connections
 
 // openDBFromPool wraps pgxpool in a *sql.DB whose Close also closes the pool
 // and optional AlloyDB dialer. stdlib.OpenDBFromPool alone leaks both.
+//
+// The pool is registered so PoolDBStats can map pgxpool.Stat into sql.DBStats
+// for observers (e.g. go-libs observability/sql MeasureStats) that call
+// db.Stats(). With MaxIdleConns=0, database/sql.DB.Stats is not meaningful.
 func openDBFromPool(pool *pgxpool.Pool, dialer *alloydbconn.Dialer) *sql.DB {
 	c := &poolConnector{
 		Connector: stdlib.GetPoolConnector(pool),
@@ -144,7 +148,75 @@ func openDBFromPool(pool *pgxpool.Pool, dialer *alloydbconn.Dialer) *sql.DB {
 	// Required when using a pgxpool-backed connector: non-zero idle conns on
 	// sql.DB prevent connections from being released back to the pool.
 	db.SetMaxIdleConns(0)
+	c.db = db
+	registerPostgresPool(db, pool)
 	return db
+}
+
+// postgresPools maps *sql.DB from openDBFromPool → underlying pgxpool.
+var postgresPools sync.Map
+
+func registerPostgresPool(db *sql.DB, pool *pgxpool.Pool) {
+	if db == nil || pool == nil {
+		return
+	}
+	postgresPools.Store(db, pool)
+}
+
+func unregisterPostgresPool(db *sql.DB) {
+	if db == nil {
+		return
+	}
+	postgresPools.Delete(db)
+}
+
+// PoolDBStats returns sql.DBStats derived from the underlying pgxpool when db
+// was opened by this package's Postgres/AlloyDB path.
+//
+// ok is false for MySQL/Spanner DBs, unknown *sql.DB values, or after Close.
+// Callers that scrape connection pressure (for example OTel db-metrics spans)
+// should prefer this over db.Stats() for Postgres from New.
+//
+// Mapping from pgxpool.Stat:
+//
+//	MaxOpenConnections ← MaxConns
+//	OpenConnections    ← TotalConns
+//	InUse              ← AcquiredConns
+//	Idle               ← IdleConns
+//	WaitCount          ← EmptyAcquireCount
+//	WaitDuration       ← EmptyAcquireWaitTime
+//	MaxIdleTimeClosed  ← MaxIdleDestroyCount
+//	MaxLifetimeClosed  ← MaxLifetimeDestroyCount
+//	MaxIdleClosed      ← 0 (no pgxpool equivalent)
+func PoolDBStats(db *sql.DB) (sql.DBStats, bool) {
+	if db == nil {
+		return sql.DBStats{}, false
+	}
+	v, ok := postgresPools.Load(db)
+	if !ok {
+		return sql.DBStats{}, false
+	}
+	pool, ok := v.(*pgxpool.Pool)
+	if !ok || pool == nil {
+		return sql.DBStats{}, false
+	}
+	return pgxPoolStatToDBStats(pool.Stat()), true
+}
+
+func pgxPoolStatToDBStats(s *pgxpool.Stat) sql.DBStats {
+	if s == nil {
+		return sql.DBStats{}
+	}
+	return sql.DBStats{
+		MaxOpenConnections: int(s.MaxConns()),
+		OpenConnections:    int(s.TotalConns()),
+		InUse:              int(s.AcquiredConns()),
+		Idle:               int(s.IdleConns()),
+		WaitCount:          s.EmptyAcquireCount(),
+		WaitDuration:       s.EmptyAcquireWaitTime(),
+		MaxIdleTimeClosed:  s.MaxIdleDestroyCount(),
+		MaxLifetimeClosed:  s.MaxLifetimeDestroyCount(),
+	}
 }
 
 // poolConnector delegates to pgx stdlib's pool connector and implements
@@ -153,6 +225,7 @@ type poolConnector struct {
 	driver.Connector
 	pool   *pgxpool.Pool
 	dialer *alloydbconn.Dialer
+	db     *sql.DB
 
 	closeOnce sync.Once
 	closeErr  error
@@ -160,6 +233,9 @@ type poolConnector struct {
 
 func (c *poolConnector) Close() error {
 	c.closeOnce.Do(func() {
+		if c.db != nil {
+			unregisterPostgresPool(c.db)
+		}
 		if c.pool != nil {
 			c.pool.Close()
 		}

--- a/database/postgres_pool_test.go
+++ b/database/postgres_pool_test.go
@@ -2,6 +2,7 @@ package database
 
 import (
 	"context"
+	"database/sql"
 	"math"
 	"testing"
 	"time"
@@ -168,4 +169,44 @@ func TestOpenDBFromPool_SetsMaxIdleConnsZero(t *testing.T) {
 	// in its own pool (OpenConns drops to 0 when unused).
 	require.Equal(t, 0, db.Stats().OpenConnections)
 	require.Equal(t, 0, db.Stats().Idle)
+}
+
+func TestPoolDBStats_FromOpenDBFromPool(t *testing.T) {
+	cfg, err := pgxpool.ParseConfig("postgres://user:pass@127.0.0.1:1/db?sslmode=disable")
+	require.NoError(t, err)
+	cfg.MaxConns = 9
+
+	pool, err := pgxpool.NewWithConfig(context.Background(), cfg)
+	require.NoError(t, err)
+
+	db := openDBFromPool(pool, nil)
+
+	// sql.DB handoff layer stays empty.
+	require.Equal(t, 0, db.Stats().OpenConnections)
+	require.Equal(t, 0, db.Stats().MaxOpenConnections)
+
+	// PoolDBStats reflects the real pgxpool.
+	got, ok := PoolDBStats(db)
+	require.True(t, ok)
+	require.Equal(t, 9, got.MaxOpenConnections)
+	require.Equal(t, int(pool.Stat().TotalConns()), got.OpenConnections)
+	require.Equal(t, int(pool.Stat().IdleConns()), got.Idle)
+	require.Equal(t, int(pool.Stat().AcquiredConns()), got.InUse)
+
+	require.NoError(t, db.Close())
+
+	_, ok = PoolDBStats(db)
+	require.False(t, ok)
+}
+
+func TestPoolDBStats_UnknownDB(t *testing.T) {
+	_, ok := PoolDBStats(nil)
+	require.False(t, ok)
+
+	_, ok = PoolDBStats(&sql.DB{})
+	require.False(t, ok)
+}
+
+func TestPgxPoolStatToDBStats_NilSafe(t *testing.T) {
+	require.Equal(t, sql.DBStats{}, pgxPoolStatToDBStats(nil))
 }


### PR DESCRIPTION
## Summary

Postgres from `database.New` now uses `pgxpool` under `OpenDBFromPool` with `MaxIdleConns=0`. That means `db.Stats()` only sees the empty `database/sql` handoff layer — so go-libs `observability/sql.MeasureStats` (which emits a periodic OTel **`db-metrics`** span from `db.Stats()`) would report near-zero pool pressure.

This PR does **not** add Prometheus scraping in base. It only exposes what observers need:

- Register the underlying `*pgxpool.Pool` when opening Postgres
- Export **`PoolDBStats(db *sql.DB) (sql.DBStats, bool)`** mapping `pgxpool.Stat` → `sql.DBStats`
- Unregister on `Close`

### Mapping

| `sql.DBStats` | `pgxpool.Stat` |
|---|---|
| MaxOpenConnections | MaxConns |
| OpenConnections | TotalConns |
| InUse | AcquiredConns |
| Idle | IdleConns |
| WaitCount / WaitDuration | EmptyAcquireCount / EmptyAcquireWaitTime |
| MaxIdleTimeClosed / MaxLifetimeClosed | MaxIdleDestroyCount / MaxLifetimeDestroyCount |

### Companion

https://github.com/moovfinancial/go-libs/pull/92 — wires `PoolDBStats` into `MeasureStats` so existing `db-metrics` spans stay accurate.

Supersedes #505 (closed).

## Test plan

- [x] `go test ./database/ -short -run 'TestPool|TestOpenDB|TestPgx|TestApply|TestResolve'`
- [ ] Land before go-libs companion (or keep go-libs pinned to this SHA until a base release)