### PR TITLE
fix(database): bound pgxpool.Close wait on sql.DB shutdown

### DIFF
--- a/database/postgres.go
+++ b/database/postgres.go
@@ -38,6 +38,12 @@ const (
 	// pgxpool defaults MaxConnLifetimeJitter to 0. Without jitter, every
 	// connection created around the same time can expire together.
 	defaultPostgresMaxConnLifetimeJitter = 30 * time.Second
+
+	// database/sql.DB.Close calls connector.Close without waiting for in-use
+	// driver connections (open Stmts/Rows/Tx). pgxpool.Close blocks until every
+	// acquired conn is returned, which deadlocks in that situation. Bound the
+	// wait so process shutdown and tests cannot hang forever.
+	defaultPostgresPoolCloseWait = 5 * time.Second
 )
 
 func postgresConnection(ctx context.Context, logger log.Logger, config PostgresConfig, databaseName string) (*sql.DB, error) {
@@ -258,11 +264,37 @@ func (c *poolConnector) Close() error {
 			unregisterPostgresPool(c.db)
 		}
 		if c.pool != nil {
-			c.pool.Close()
+			c.closeErr = closePgxPool(c.pool, defaultPostgresPoolCloseWait)
 		}
-		c.closeErr = closeAlloyDialer(c.dialer)
+		if err := closeAlloyDialer(c.dialer); err != nil && c.closeErr == nil {
+			c.closeErr = err
+		}
 	})
 	return c.closeErr
+}
+
+// closePgxPool closes pool, returning an error if acquired connections prevent
+// shutdown within wait. The close continues in the background on timeout so
+// connections released later are still reaped.
+func closePgxPool(pool *pgxpool.Pool, wait time.Duration) error {
+	if pool == nil {
+		return nil
+	}
+	done := make(chan struct{})
+	go func() {
+		pool.Close()
+		close(done)
+	}()
+	if wait <= 0 {
+		<-done
+		return nil
+	}
+	select {
+	case <-done:
+		return nil
+	case <-time.After(wait):
+		return fmt.Errorf("pgxpool close timed out after %s; open Stmts/Rows/Tx may still hold connections", wait)
+	}
 }
 
 func closeAlloyDialer(dialer *alloydbconn.Dialer) error {

--- a/database/postgres_pool_test.go
+++ b/database/postgres_pool_test.go
@@ -161,6 +161,26 @@ func TestOpenDBFromPool_CloseClosesPool(t *testing.T) {
 	require.Contains(t, err.Error(), "closed")
 }
 
+func TestClosePgxPool_EmptyPool(t *testing.T) {
+	cfg, err := pgxpool.ParseConfig("postgres://user:pass@127.0.0.1:1/db?sslmode=disable")
+	require.NoError(t, err)
+
+	pool, err := pgxpool.NewWithConfig(context.Background(), cfg)
+	require.NoError(t, err)
+
+	start := time.Now()
+	require.NoError(t, closePgxPool(pool, defaultPostgresPoolCloseWait))
+	require.Less(t, time.Since(start), 2*time.Second)
+
+	_, err = pool.Acquire(context.Background())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "closed")
+}
+
+func TestClosePgxPool_NilSafe(t *testing.T) {
+	require.NoError(t, closePgxPool(nil, time.Second))
+}
+
 func TestOpenDBFromPool_CloseIdempotent(t *testing.T) {
 	cfg, err := pgxpool.ParseConfig("postgres://user:pass@127.0.0.1:1/db?sslmode=disable")
 	require.NoError(t, err)


### PR DESCRIPTION
## Summary

`pgxpool.Close` blocks until all acquired connections are returned. `database/sql.DB.Close` calls `connector.Close` **without** waiting for in-use driver conns (open Stmts/Rows/Tx). That combination deadlocks — seen in go-libs CI as `Test_SQL_Prepare` hanging 10m in `poolConnector.Close` → `puddle.Wait`.

Bound the wait to **5s** and let close finish in the background on timeout.

## Test plan

- [x] `go test ./database/ -short -run 'TestOpenDB|TestClosePgx|TestPool|TestApply|TestResolve|TestDefault'`
- [ ] Patch release after merge for go-libs