### PR TITLE
fix(http): require CORS origin allowlist for credentialed responses

### DIFF
--- a/http/response_test.go
+++ b/http/response_test.go
@@ -21,8 +21,12 @@ var (
 )
 
 func TestResponse__Wrap(t *testing.T) {
+	t.Setenv(CORSAllowedOriginsEnv, "https://moov.io")
+	ResetCORSAllowlistForTest()
+	t.Cleanup(ResetCORSAllowlistForTest)
+
 	req := httptest.NewRequest("GET", "https://api.moov.io/v1/ach/ping", nil)
-	req.Header.Set("Origin", "https://moov.io/demo")
+	req.Header.Set("Origin", "https://moov.io")
 
 	w := httptest.NewRecorder()
 

--- a/http/server.go
+++ b/http/server.go
@@ -11,10 +11,12 @@ import (
 	"math"
 	"net/http"
 	"net/url"
+	"os"
 	"path/filepath"
 	"runtime"
 	"strconv"
 	"strings"
+	"sync"
 
 	"github.com/gorilla/mux"
 	"github.com/moov-io/base/strx"
@@ -92,19 +94,60 @@ func AddCORSHandler(r *mux.Router) {
 	})
 }
 
+// CORSAllowedOriginsEnv is a comma-separated list of exact Origins permitted for
+// credentialed CORS. Example: "https://moov.io,https://dashboard.moov.io".
+// Localhost (http://localhost:<port>) remains allowed for development.
+const CORSAllowedOriginsEnv = "MOOV_CORS_ALLOW_ORIGINS"
+
+var (
+	corsAllowlistOnce sync.Once
+	corsAllowlist     map[string]struct{}
+)
+
+func loadCORSAllowlist() map[string]struct{} {
+	corsAllowlistOnce.Do(func() {
+		corsAllowlist = make(map[string]struct{})
+		for _, part := range strings.Split(os.Getenv(CORSAllowedOriginsEnv), ",") {
+			origin := strings.TrimSpace(part)
+			if origin != "" {
+				corsAllowlist[origin] = struct{}{}
+			}
+		}
+	})
+	return corsAllowlist
+}
+
+// ResetCORSAllowlistForTest clears the cached allowlist. Intended for tests only.
+func ResetCORSAllowlistForTest() {
+	corsAllowlistOnce = sync.Once{}
+	corsAllowlist = nil
+}
+
+func originAllowedForCORS(origin string) bool {
+	if origin == "" {
+		return false
+	}
+	// Dev convenience: any localhost HTTP origin.
+	if strings.HasPrefix(origin, "http://localhost:") {
+		return true
+	}
+	_, ok := loadCORSAllowlist()[origin]
+	return ok
+}
+
 // SetAccessControlAllowHeaders writes Access-Control-Allow-* headers to a response to allow
 // for further CORS-allowed requests.
 func SetAccessControlAllowHeaders(w http.ResponseWriter, origin string) {
 	// Access-Control-Allow-Origin can't be '*' with requests that send credentials.
-	// Instead, we need to explicitly set the domain (from request's Origin header)
-	//
-	// Allow requests from anyone's localhost and only from secure pages.
-	if strings.HasPrefix(origin, "http://localhost:") || strings.HasPrefix(origin, "https://") {
-		w.Header().Set("Access-Control-Allow-Origin", origin)
-		w.Header().Set("Access-Control-Allow-Methods", "GET,POST,PATCH,DELETE,OPTIONS")
-		w.Header().Set("Access-Control-Allow-Headers", "Cookie,X-User-Id,X-Request-Id,Content-Type")
-		w.Header().Set("Access-Control-Allow-Credentials", "true")
+	// Reflect only explicitly allowlisted Origins (plus localhost for local dev).
+	// Never reflect arbitrary https:// Origins with Allow-Credentials: true.
+	if !originAllowedForCORS(origin) {
+		return
 	}
+	w.Header().Set("Access-Control-Allow-Origin", origin)
+	w.Header().Set("Access-Control-Allow-Methods", "GET,POST,PATCH,DELETE,OPTIONS")
+	w.Header().Set("Access-Control-Allow-Headers", "Cookie,X-User-Id,X-Request-Id,Content-Type")
+	w.Header().Set("Access-Control-Allow-Credentials", "true")
 }
 
 // GetRequestID returns the Moov header value for request IDs

--- a/http/server_test.go
+++ b/http/server_test.go
@@ -25,7 +25,16 @@ func truncate(s string) string {
 	return s
 }
 
+func withCORSAllowOrigins(t *testing.T, origins string) {
+	t.Helper()
+	t.Setenv(CORSAllowedOriginsEnv, origins)
+	ResetCORSAllowlistForTest()
+	t.Cleanup(ResetCORSAllowlistForTest)
+}
+
 func TestHTTP__AddCORSHandler(t *testing.T) {
+	withCORSAllowOrigins(t, "https://moov.io")
+
 	router := mux.NewRouter()
 	w := httptest.NewRecorder()
 	r := httptest.NewRequest("OPTIONS", "https://api.moov.io/v1/auth/ping", nil)
@@ -51,6 +60,29 @@ func TestHTTP__AddCORSHandler(t *testing.T) {
 		if v == "" {
 			t.Errorf("%s's value is an empty string", headers[i])
 		}
+	}
+}
+
+func TestHTTP__CORSRejectsUnlistedHTTPSOrigin(t *testing.T) {
+	withCORSAllowOrigins(t, "https://moov.io")
+
+	w := httptest.NewRecorder()
+	SetAccessControlAllowHeaders(w, "https://evil.example")
+	if v := w.Header().Get("Access-Control-Allow-Origin"); v != "" {
+		t.Errorf("expected no ACAO for unlisted origin, got %q", v)
+	}
+	if v := w.Header().Get("Access-Control-Allow-Credentials"); v != "" {
+		t.Errorf("expected no credentials header for unlisted origin, got %q", v)
+	}
+}
+
+func TestHTTP__CORSAllowsLocalhost(t *testing.T) {
+	withCORSAllowOrigins(t, "")
+
+	w := httptest.NewRecorder()
+	SetAccessControlAllowHeaders(w, "http://localhost:3000")
+	if v := w.Header().Get("Access-Control-Allow-Origin"); v != "http://localhost:3000" {
+		t.Errorf("got %q", v)
 	}
 }
 


### PR DESCRIPTION
## Summary
- `SetAccessControlAllowHeaders` previously reflected any `https://` Origin with `Access-Control-Allow-Credentials: true` (and allowed Cookie / X-User-Id).
- Require an explicit allowlist via `MOOV_CORS_ALLOW_ORIGINS` (comma-separated exact Origins).
- Keep `http://localhost:<port>` allowed for local development.
- Update tests; add coverage that unlisted https Origins get no ACAO / credentials headers.

## Test plan
- [x] `go test ./http/ -count=1`
- [x] Allowlisted Origin still receives CORS headers
- [x] Unlisted `https://evil.example` receives none
- [x] Localhost still allowed

## Deploy note
Set `MOOV_CORS_ALLOW_ORIGINS=https://moov.io,...` (exact browser Origins) in environments that rely on credentialed browser calls.


Made with [Cursor](https://cursor.com)