### PR TITLE
fix(randx): use upper bound in Between

### DIFF
--- a/randx/randx.go
+++ b/randx/randx.go
@@ -2,12 +2,18 @@ package randx
 
 import (
 	"crypto/rand"
+	"fmt"
 	"math/big"
 )
 
-// Between will return a randomly generated integer within the lower and upper bounds provided.
+// Between will return a randomly generated integer within the lower (inclusive)
+// and upper (exclusive) bounds provided.
 func Between(lower, upper int) (int64, error) {
-	n, err := rand.Int(rand.Reader, big.NewInt(int64(lower)))
+	if upper <= lower {
+		return 0, fmt.Errorf("randx.Between: upper bound %d must be greater than lower bound %d", upper, lower)
+	}
+
+	n, err := rand.Int(rand.Reader, big.NewInt(int64(upper-lower)))
 	if err != nil {
 		return 0, err
 	}

--- a/randx/randx_test.go
+++ b/randx/randx_test.go
@@ -9,20 +9,48 @@ import (
 func TestBetween(t *testing.T) {
 	lower, upper := 100, 250
 
-	n, err := Between(lower, upper)
-	require.NoError(t, err)
+	for i := 0; i < 1000; i++ {
+		n, err := Between(lower, upper)
+		require.NoError(t, err)
 
-	if n < int64(lower) || n > int64(upper) {
-		t.Fatalf("%d falls outside of %d and %d", n, lower, upper)
+		require.GreaterOrEqual(t, n, int64(lower))
+		require.Less(t, n, int64(upper))
 	}
+}
+
+func TestBetween_ZeroLower(t *testing.T) {
+	for i := 0; i < 1000; i++ {
+		n, err := Between(0, 10)
+		require.NoError(t, err)
+
+		require.GreaterOrEqual(t, n, int64(0))
+		require.Less(t, n, int64(10))
+	}
+}
+
+func TestBetween_InvalidBounds(t *testing.T) {
+	n, err := Between(250, 100)
+	require.Error(t, err)
+	require.Equal(t, int64(0), n)
+
+	n, err = Between(100, 100)
+	require.Error(t, err)
+	require.Equal(t, int64(0), n)
 }
 
 func TestMust(t *testing.T) {
 	lower, upper := 1000, 25000
 
-	n := Must(Between(lower, upper))
+	for i := 0; i < 1000; i++ {
+		n := Must(Between(lower, upper))
 
-	if n < int64(lower) || n > int64(upper) {
-		t.Fatalf("%d falls outside of %d and %d", n, lower, upper)
+		require.GreaterOrEqual(t, n, int64(lower))
+		require.Less(t, n, int64(upper))
 	}
+}
+
+func TestMust_Panics(t *testing.T) {
+	require.Panics(t, func() {
+		Must(Between(100, 100))
+	})
 }


### PR DESCRIPTION
## Problem

`randx.Between(lower, upper)` never reads `upper`. It passes `lower` as the exclusive maximum to `crypto/rand.Int` and then adds `lower` to the result, so the returned value falls in `[lower, 2*lower)` instead of `[lower, upper)`.

The existing test only passes because `[100, 200)` loosely overlaps the asserted range of `[100, 250]`.

Additionally, when `lower == 0`, `crypto/rand.Int` is called with a maximum of 0 and panics, so any caller doing `Between(0, n)` crashes the process.

## Fix

- Compute the range as `upper - lower`, draw from `[0, upper-lower)`, and shift the result by `lower`, yielding a uniform value in `[lower, upper)`.
- Return an explicit error when `upper <= lower` instead of panicking inside `crypto/rand`. This matches the package's existing style where `Between` returns errors and `Must` panics on them.

## Tests

- `TestBetween` and `TestMust` now assert both bounds tightly over 1000 samples (`lower <= n < upper`).
- `TestBetween_ZeroLower` covers `lower == 0`, which previously panicked.
- `TestBetween_InvalidBounds` and `TestMust_Panics` cover the `upper <= lower` error path.

Verified that the new tests fail against the old implementation (the zero-lower test panics in `crypto/rand.Int`).

Made with [Cursor](https://cursor.com)